### PR TITLE
Simplify tokens

### DIFF
--- a/projects/circe/src/circe/main-visitor.cpp
+++ b/projects/circe/src/circe/main-visitor.cpp
@@ -3,6 +3,8 @@
 
 #include <mana/vm/opcode.hpp>
 
+#include <magic_enum/magic_enum.hpp>
+
 namespace circe {
 using namespace mana::vm;
 using namespace sigil::ast;

--- a/projects/sigil/CMakeLists.txt
+++ b/projects/sigil/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SIGIL_SOURCES
         src/sigil/ast/parser.cpp
         src/sigil/ast/parse-tree.cpp
         src/sigil/ast/syntax-tree.cpp
+        src/sigil/ast/source-file.cpp
 
         src/sigil/core/logger.cpp
 

--- a/projects/sigil/include/sigil/ast/keywords.hpp
+++ b/projects/sigil/include/sigil/ast/keywords.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
 #include <sigil/ast/token.hpp>
-#include <string>
+
 #include <unordered_map>
 
 namespace sigil {
 
-// TODO: Make this use const char* instead of std::string
-using KeywordMap = std::unordered_map<std::string, TokenType>;
+using KeywordMap = std::unordered_map<const char*, TokenType>;
 
 static const KeywordMap keyword_map = {
     {"i8",       TokenType::KW_i8        },

--- a/projects/sigil/include/sigil/ast/keywords.hpp
+++ b/projects/sigil/include/sigil/ast/keywords.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <sigil/ast/token.hpp>
+#include <string>
+#include <unordered_map>
+
+namespace sigil {
+
+// TODO: Make this use const char* instead of std::string
+using KeywordMap = std::unordered_map<std::string, TokenType>;
+
+static const KeywordMap keyword_map = {
+    {"i8",       TokenType::KW_i8        },
+    {"i16",      TokenType::KW_i16       },
+    {"i32",      TokenType::KW_i32       },
+    {"i64",      TokenType::KW_i64       },
+    {"i128",     TokenType::KW_i128      },
+
+    {"u8",       TokenType::KW_u8        },
+    {"u16",      TokenType::KW_u16       },
+    {"u32",      TokenType::KW_u32       },
+    {"u64",      TokenType::KW_u64       },
+    {"u128",     TokenType::KW_u128      },
+
+    {"f32",      TokenType::KW_f32       },
+    {"f64",      TokenType::KW_f64       },
+
+    {"byte",     TokenType::KW_byte      },
+    {"char",     TokenType::KW_char      },
+    {"string",   TokenType::KW_string    },
+
+    {"bool",     TokenType::KW_bool      },
+    {"null",     TokenType::Lit_null     },
+
+    {"data",     TokenType::KW_data      },
+    {"fn",       TokenType::KW_fn        },
+    {"mut",      TokenType::KW_mut       },
+    {"raw",      TokenType::KW_raw       },
+    {"const",    TokenType::KW_const     },
+    {"override", TokenType::KW_override  },
+
+    {"pack",     TokenType::KW_pack      },
+    {"struct",   TokenType::KW_struct    },
+    {"enum",     TokenType::KW_enum      },
+    {"generic",  TokenType::KW_generic   },
+
+    {"module",   TokenType::KW_artifact  },
+    {"public",   TokenType::KW_public    },
+    {"private",  TokenType::KW_private   },
+    {"import",   TokenType::KW_import    },
+    {"as",       TokenType::KW_as        },
+
+    {"return",   TokenType::KW_return    },
+    {"true",     TokenType::Lit_true     },
+    {"false",    TokenType::Lit_false    },
+    {"if",       TokenType::KW_if        },
+    {"else",     TokenType::KW_else      },
+    {"match",    TokenType::KW_match     },
+
+    {"loop",     TokenType::KW_loop      },
+    {"while",    TokenType::KW_while     },
+    {"for",      TokenType::KW_for       },
+    {"break",    TokenType::KW_break     },
+    {"skip",     TokenType::KW_skip      },
+
+    {"and",      TokenType::Op_LogicalAnd},
+    {"or",       TokenType::Op_LogicalOr },
+    {"not",      TokenType::Op_LogicalNot},
+};
+
+}  // namespace sigil

--- a/projects/sigil/include/sigil/ast/lexer.hpp
+++ b/projects/sigil/include/sigil/ast/lexer.hpp
@@ -55,8 +55,4 @@ private:
     void AddEOF();
 };
 
-SIGIL_NODISCARD inline std::string_view FetchTokenText(const Token token) {
-    return Lexer::Source.Slice(token.offset, token.length);
-}
-
 } // namespace sigil

--- a/projects/sigil/include/sigil/ast/lexer.hpp
+++ b/projects/sigil/include/sigil/ast/lexer.hpp
@@ -5,8 +5,10 @@
 
 #include <mana/literals.hpp>
 
+#include <string_view>
 #include <filesystem>
 #include <string>
+#include <vector>
 
 namespace sigil {
 namespace ml = mana::literals;
@@ -17,7 +19,7 @@ class Lexer {
     ml::i32 line_start;
     ml::i32 line_number;
 
-    TokenStream tokens;
+    std::vector<Token> tokens;
 
 public:
     static thread_local GlobalSourceFile Source;
@@ -28,7 +30,7 @@ public:
     void PrintTokens() const;
     void Reset();
 
-    SIGIL_NODISCARD TokenStream&& RelinquishTokens();
+    SIGIL_NODISCARD std::vector<Token>&& RelinquishTokens();
 
 private:
     void TokenizeLine();

--- a/projects/sigil/include/sigil/ast/lexer.hpp
+++ b/projects/sigil/include/sigil/ast/lexer.hpp
@@ -11,40 +11,51 @@
 namespace sigil {
 namespace ml = mana::literals;
 
+struct TokenizedSource {
+    std::string source;
+    std::vector<Token> tokens;
+};
+
 class Lexer {
+    ml::i64 cursor;
+
+    ml::i64 line_start;
+    ml::i64 line_number;
+
+    TokenStream token_stream;
+    std::string source;
 public:
     Lexer();
 
-    void TokenizeLine(std::string_view line);
     bool Tokenize(const std::filesystem::path& file_path);
     void PrintTokens() const;
-    void clear();
+    void Reset();
 
     SIGIL_NODISCARD TokenStream&& RelinquishTokens();
 
 private:
-    SIGIL_NODISCARD bool LexedIdentifier(std::string_view line);
-    SIGIL_NODISCARD bool LexedString(std::string_view line);
-    SIGIL_NODISCARD bool LexedNumber(std::string_view line);
-    SIGIL_NODISCARD bool LexedOperator(std::string_view line);
+    void TokenizeLine();
 
-    void LexUnknown(std::string_view line);
+    mana::literals::i64  GetTokenColumnIndex(std::size_t token_length);
+
+    void AddToken(TokenType type, std::string&& text);
+    void AddToken(TokenType type, std::string& text);
+    void AddToken(TokenType type, char c);
+
+    SIGIL_NODISCARD bool LexedIdentifier();
+    SIGIL_NODISCARD bool LexedString();
+    SIGIL_NODISCARD bool LexedNumber();
+    SIGIL_NODISCARD bool LexedOperator();
+
+    void LexUnknown();
 
     SIGIL_NODISCARD bool MatchedKeyword(std::string& identifier_buffer);
 
     SIGIL_NODISCARD bool IsWhitespace(char c) const;
-    SIGIL_NODISCARD bool IsComment(char c) const;
-
-    void AddToken(TokenType type, std::string&& text);
-    void AddToken(TokenType type, std::string& text);
+    SIGIL_NODISCARD bool IsLineComment(char c) const;
+    SIGIL_NODISCARD bool IsTerminator() const;
 
     void AddEOF();
-
-private:
-    ml::i64 cursor;
-    ml::i64 line_number;
-
-    TokenStream token_stream;
 };
 
 }  // namespace sigil

--- a/projects/sigil/include/sigil/ast/parse-tree.hpp
+++ b/projects/sigil/include/sigil/ast/parse-tree.hpp
@@ -13,12 +13,11 @@ class ParseNode {
     ParseNode* parent;
 
 public:
-    using Ptr        = std::shared_ptr<ParseNode>;
-    using BranchList = std::vector<Ptr>;
+    using Branch      = std::shared_ptr<ParseNode>;
 
-    BranchList  branches;
-    TokenStream tokens;
-    ast::Rule   rule;
+    std::vector<Branch> branches;
+    std::vector<Token>  tokens;
+    ast::Rule           rule;
 
     explicit ParseNode(ast::Rule rule = ast::Rule::Undefined);
     explicit ParseNode(ParseNode* parent, ast::Rule rule = ast::Rule::Undefined);

--- a/projects/sigil/include/sigil/ast/parse-tree.hpp
+++ b/projects/sigil/include/sigil/ast/parse-tree.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 namespace sigil {
-
 class ParseNode {
     ParseNode* parent;
 
@@ -17,9 +16,9 @@ public:
     using Ptr        = std::shared_ptr<ParseNode>;
     using BranchList = std::vector<Ptr>;
 
-    ast::Rule   rule;
-    TokenStream tokens;
     BranchList  branches;
+    TokenStream tokens;
+    ast::Rule   rule;
 
     explicit ParseNode(ast::Rule rule = ast::Rule::Undefined);
     explicit ParseNode(ParseNode* parent, ast::Rule rule = ast::Rule::Undefined);
@@ -38,5 +37,4 @@ public:
     void AcquireBranchesOf(ParseNode& target, ml::i64 start);
     void AcquireTailBranchOf(ParseNode& target);
 };
-
-}  // namespace sigil
+} // namespace sigil

--- a/projects/sigil/include/sigil/ast/parser.hpp
+++ b/projects/sigil/include/sigil/ast/parser.hpp
@@ -6,8 +6,6 @@
 
 #include <mana/literals.hpp>
 
-#include <vector>
-
 namespace sigil {
 namespace ml = mana::literals;
 
@@ -15,9 +13,9 @@ class Parser {
     using ASTNode = std::unique_ptr<ast::Node>;
 
     TokenStream tokens;
-    ml::i64     cursor;
-    ParseNode   parse_tree;
-    ASTNode     syntax_tree;
+    ml::i64   cursor;
+    ParseNode parse_tree;
+    ASTNode   syntax_tree;
 
 public:
     explicit Parser(const TokenStream&& tokens);
@@ -25,9 +23,9 @@ public:
 
     SIGIL_NODISCARD bool Parse();
 
-    SIGIL_NODISCARD auto ViewParseTree() const -> const ParseNode&;
-    SIGIL_NODISCARD auto ViewTokens() const -> const TokenStream&;
-    SIGIL_NODISCARD auto ViewAST() const -> ast::Node*;
+    SIGIL_NODISCARD const ParseNode&   ViewParseTree() const;
+    SIGIL_NODISCARD const TokenStream& ViewTokenStream() const;
+    SIGIL_NODISCARD ast::Node*         ViewAST() const;
 
     void PrintParseTree() const;
     void EmitParseTree(std::string_view file_name) const;
@@ -37,10 +35,10 @@ public:
 private:
     SIGIL_NODISCARD std::string EmitParseTree(const ParseNode& node, std::string prepend = "") const;
 
-    SIGIL_NODISCARD const Token& CurrentToken() const;
-    SIGIL_NODISCARD const Token& PeekNextToken() const;
-    SIGIL_NODISCARD const Token& NextToken();
-    SIGIL_NODISCARD const Token& GetAndCycleToken();
+    SIGIL_NODISCARD Token CurrentToken() const;
+    SIGIL_NODISCARD Token PeekNextToken() const;
+    SIGIL_NODISCARD Token NextToken();
+    SIGIL_NODISCARD Token GetAndCycleToken();
 
     bool SkipNewlines();
 
@@ -55,7 +53,7 @@ private:
     bool ProgressedParseTree(ParseNode& node);
 
     void ConstructAST(const ParseNode& node);
-    bool Expect(bool condition, std::string_view error_message, ParseNode& node);
+    bool Expect(bool condition, ParseNode& node, std::string_view error_message);
 
     // Matchers
     bool MatchedStatement(ParseNode& node);
@@ -85,5 +83,4 @@ private:
         ast::Rule      rule
     );
 };
-
-}  // namespace sigil
+} // namespace sigil

--- a/projects/sigil/include/sigil/ast/parser.hpp
+++ b/projects/sigil/include/sigil/ast/parser.hpp
@@ -10,12 +10,13 @@ namespace sigil {
 namespace ml = mana::literals;
 
 class Parser {
-    using ASTNode = std::unique_ptr<ast::Node>;
+    using ASTNode     = std::unique_ptr<ast::Node>;
+    using TokenStream = std::vector<Token>;
 
     TokenStream tokens;
-    ml::i64   cursor;
-    ParseNode parse_tree;
-    ASTNode   syntax_tree;
+    ml::i64     cursor;
+    ParseNode   parse_tree;
+    ASTNode     syntax_tree;
 
 public:
     explicit Parser(const TokenStream&& tokens);

--- a/projects/sigil/include/sigil/ast/parser.hpp
+++ b/projects/sigil/include/sigil/ast/parser.hpp
@@ -55,10 +55,10 @@ private:
     bool ProgressedParseTree(ParseNode& node);
 
     void ConstructAST(const ParseNode& node);
+    bool Expect(bool condition, std::string_view error_message, ParseNode& node);
 
     // Matchers
     bool MatchedStatement(ParseNode& node);
-    bool Expect(bool condition, std::string_view error_message, ParseNode& node);
 
     bool MatchedDeclaration(ParseNode& node);
     bool MatchedAssignment(ParseNode& node);

--- a/projects/sigil/include/sigil/ast/rule.hpp
+++ b/projects/sigil/include/sigil/ast/rule.hpp
@@ -5,7 +5,7 @@
 namespace sigil::ast {
 namespace ml = mana::literals;
 
-enum class Rule : ml::i64 {
+enum class Rule : ml::u8 {
     Undefined,
     Mistake,
 
@@ -31,7 +31,6 @@ enum class Rule : ml::i64 {
 
     // ReachedEOF,
     //
-    // Declaration,
     // Decl_Import,
     // Decl_Access,
     // Decl_Function,
@@ -52,9 +51,7 @@ enum class Rule : ml::i64 {
     // Type_Association,
     //
     // Scope,
-    // Statement,
     // Return,
-    // Assignment,
     // Arguments,
     // MemberAccess,
     //

--- a/projects/sigil/include/sigil/ast/source-file.hpp
+++ b/projects/sigil/include/sigil/ast/source-file.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <sigil/core/logger.hpp>
+
+#include <string>
+#include <fstream>
+#include <filesystem>
+
+namespace sigil {
+// struct TokenizedSource {
+//     std::string artifact;
+//     std::string source;
+//     TokenStream stream;
+// };
+
+// perhaps add some safeguards for parallelisation in the future
+class GlobalSourceFile {
+    friend class Lexer;
+
+    std::string name;
+    std::string contents;
+    uintmax_t size;
+
+    GlobalSourceFile() = default;
+
+    GlobalSourceFile(const GlobalSourceFile&) = delete;
+    GlobalSourceFile& operator=(const GlobalSourceFile&) = delete;
+    GlobalSourceFile(GlobalSourceFile&&) = delete;
+    GlobalSourceFile& operator=(GlobalSourceFile&&) = delete;
+
+private:
+    bool Load(const std::filesystem::path& file_path) {
+        std::ifstream source_file(file_path);
+        if (not source_file.is_open()) {
+            Log->error("Failed to open file at '{}'", file_path.string());
+            return false;
+        }
+
+        size = std::filesystem::file_size(file_path);
+        contents.resize(size);
+        source_file.read(contents.data(), size);
+        source_file.close();
+
+        name = file_path.filename().replace_extension("").string();
+
+        return true;
+    }
+
+    void Reset() {
+        contents.clear();
+        name.clear();
+    }
+
+public:
+    std::string_view Name() const {
+        return name;
+    }
+
+    std::string_view Content() const {
+        return contents;
+    }
+
+    std::string_view Slice(const std::size_t start, const std::size_t length) const {
+        return contents.substr(start, length);
+    }
+
+    uintmax_t Size() const {
+        return size;
+    }
+
+    char operator[](const std::size_t index) const {
+        return contents[index];
+    }
+};
+
+} // namespace sigil

--- a/projects/sigil/include/sigil/ast/source-file.hpp
+++ b/projects/sigil/include/sigil/ast/source-file.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <sigil/core/logger.hpp>
-
 #include <string>
-#include <fstream>
 #include <filesystem>
 
 namespace sigil {
@@ -36,4 +33,7 @@ public:
 
     char operator[](std::size_t index) const;
 };
+
+SIGIL_NODISCARD const GlobalSourceFile& Source();
+SIGIL_NODISCARD std::string_view FetchTokenText(struct Token token);
 } // namespace sigil

--- a/projects/sigil/include/sigil/ast/source-file.hpp
+++ b/projects/sigil/include/sigil/ast/source-file.hpp
@@ -19,6 +19,7 @@ class GlobalSourceFile {
 
     std::string name;
     std::string contents;
+    std::string_view view;
     uintmax_t size;
 
     GlobalSourceFile() = default;
@@ -43,6 +44,8 @@ private:
 
         name = file_path.filename().replace_extension("").string();
 
+        view = contents;
+
         return true;
     }
 
@@ -61,7 +64,7 @@ public:
     }
 
     std::string_view Slice(const std::size_t start, const std::size_t length) const {
-        return contents.substr(start, length);
+        return view.substr(start, length);
     }
 
     uintmax_t Size() const {

--- a/projects/sigil/include/sigil/ast/source-file.hpp
+++ b/projects/sigil/include/sigil/ast/source-file.hpp
@@ -7,73 +7,33 @@
 #include <filesystem>
 
 namespace sigil {
-// struct TokenizedSource {
-//     std::string artifact;
-//     std::string source;
-//     TokenStream stream;
-// };
-
 // perhaps add some safeguards for parallelisation in the future
 class GlobalSourceFile {
     friend class Lexer;
 
     std::string name;
     std::string contents;
+    std::size_t size;
+
     std::string_view view;
-    uintmax_t size;
 
     GlobalSourceFile() = default;
-
-    GlobalSourceFile(const GlobalSourceFile&) = delete;
+    GlobalSourceFile(const GlobalSourceFile&)            = delete;
     GlobalSourceFile& operator=(const GlobalSourceFile&) = delete;
-    GlobalSourceFile(GlobalSourceFile&&) = delete;
-    GlobalSourceFile& operator=(GlobalSourceFile&&) = delete;
+    GlobalSourceFile(GlobalSourceFile&&)                 = delete;
+    GlobalSourceFile& operator=(GlobalSourceFile&&)      = delete;
 
 private:
-    bool Load(const std::filesystem::path& file_path) {
-        std::ifstream source_file(file_path);
-        if (not source_file.is_open()) {
-            Log->error("Failed to open file at '{}'", file_path.string());
-            return false;
-        }
-
-        size = std::filesystem::file_size(file_path);
-        contents.resize(size);
-        source_file.read(contents.data(), size);
-        source_file.close();
-
-        name = file_path.filename().replace_extension("").string();
-
-        view = contents;
-
-        return true;
-    }
-
-    void Reset() {
-        contents.clear();
-        name.clear();
-    }
+    bool Load(const std::filesystem::path& file_path);
+    void Reset();
 
 public:
-    std::string_view Name() const {
-        return name;
-    }
+    std::size_t Size() const;
 
-    std::string_view Content() const {
-        return contents;
-    }
+    std::string_view Name() const;
+    std::string_view Content() const;
+    std::string_view Slice(std::size_t start, std::size_t length) const;
 
-    std::string_view Slice(const std::size_t start, const std::size_t length) const {
-        return view.substr(start, length);
-    }
-
-    uintmax_t Size() const {
-        return size;
-    }
-
-    char operator[](const std::size_t index) const {
-        return contents[index];
-    }
+    char operator[](std::size_t index) const;
 };
-
 } // namespace sigil

--- a/projects/sigil/include/sigil/ast/syntax-tree.hpp
+++ b/projects/sigil/include/sigil/ast/syntax-tree.hpp
@@ -16,35 +16,36 @@ namespace ml = mana::literals;
 
 class Visitor;
 
+using NodePtr = std::shared_ptr<class Node>;
+
 // As the ptree gets constructed before the AST,
 // AST nodes assume their ptree input is correct
 class Node {
 public:
-    using Ptr       = std::shared_ptr<Node>;  // TODO: rename to NodePtr
     virtual ~Node() = default;
 
     virtual void Accept(Visitor& visitor) const = 0;
 };
 
 class Statement final : public Node {
-    Ptr child;
+    NodePtr child;
 
 public:
-    explicit Statement(const Ptr&& node);
+    explicit Statement(const NodePtr&& node);
 
     void Accept(Visitor& visitor) const override;
 };
 
 class Artifact final : public Node {
-    std::string      name;
-    std::vector<Ptr> children;
+    std::string          name;
+    std::vector<NodePtr> children;
 
 public:
     explicit Artifact(const std::string_view name)
         : name(name) {}
 
     SIGIL_NODISCARD auto GetName() const -> std::string_view;
-    SIGIL_NODISCARD auto GetChildren() const -> const std::vector<Ptr>&;
+    SIGIL_NODISCARD auto GetChildren() const -> const std::vector<NodePtr>&;
 
     void Accept(Visitor& visitor) const override;
 
@@ -86,24 +87,24 @@ public:
 };
 
 class ArrayLiteral final : public Node {
-    std::vector<Ptr>    values;
-    mana::PrimitiveType type;
+    std::vector<NodePtr> values;
+    mana::PrimitiveType  type;
 
 public:
     ArrayLiteral(const ParseNode& node);
 
-    const std::vector<Ptr>& GetValues() const;
-    mana::PrimitiveType     GetType() const;
+    const std::vector<NodePtr>& GetValues() const;
+    mana::PrimitiveType         GetType() const;
 
     void Accept(Visitor& visitor) const override;
 
 private:
-    Ptr ProcessValue(const ParseNode& elem);
+    NodePtr ProcessValue(const ParseNode& elem);
 };
 
 class BinaryExpr final : public Node {
     std::string op;
-    Ptr         left, right;
+    NodePtr     left, right;
 
 public:
     explicit BinaryExpr(const ParseNode& node);
@@ -118,13 +119,13 @@ public:
     void Accept(Visitor& visitor) const override;
 
 private:
-    static Ptr ConstructChild(const ParseNode& operand_node);
-    explicit BinaryExpr(const ParseNode& binary_node, ml::i64 depth);
+    static NodePtr ConstructChild(const ParseNode& operand_node);
+    explicit       BinaryExpr(const ParseNode& binary_node, ml::i64 depth);
 };
 
 class UnaryExpr final : public Node {
     std::string op;
-    Ptr         val;
+    NodePtr     val;
 
 public:
     explicit UnaryExpr(const ParseNode& unary_node);
@@ -134,5 +135,4 @@ public:
     SIGIL_NODISCARD std::string_view GetOp() const;
     SIGIL_NODISCARD const Node&      GetVal() const;
 };
-
-}  // namespace sigil::ast
+} // namespace sigil::ast

--- a/projects/sigil/include/sigil/ast/syntax-tree.hpp
+++ b/projects/sigil/include/sigil/ast/syntax-tree.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <charconv>
 
 namespace sigil::ast {
 namespace ml = mana::literals;

--- a/projects/sigil/include/sigil/ast/syntax-tree.hpp
+++ b/projects/sigil/include/sigil/ast/syntax-tree.hpp
@@ -64,6 +64,10 @@ public:
     explicit Literal(T value)
         : value(value) {}
 
+    explicit Literal(const std::string_view str) {
+        std::from_chars(str.data(), str.data() + str.size(), value);
+    }
+
     SIGIL_NODISCARD T Get() const {
         return value;
     }
@@ -104,6 +108,7 @@ class BinaryExpr final : public Node {
 public:
     explicit BinaryExpr(const ParseNode& node);
     explicit BinaryExpr(const std::string& op, const ParseNode& left, const ParseNode& right);
+    explicit BinaryExpr(const std::string_view op, const ParseNode& left, const ParseNode& right);
 
     SIGIL_NODISCARD std::string_view GetOp() const;
 

--- a/projects/sigil/include/sigil/ast/token.hpp
+++ b/projects/sigil/include/sigil/ast/token.hpp
@@ -1,13 +1,6 @@
 #pragma once
 
-#include <sigil/core/logger.hpp>
-
 #include <mana/literals.hpp>
-
-#include <magic_enum/magic_enum.hpp>
-
-#include <string>
-#include <vector>
 
 namespace sigil {
 namespace ml = mana::literals;
@@ -112,7 +105,6 @@ enum class TokenType : ml::u8 {
     Eof,
 
     Unknown,
-    _artifact_, // special token, auto-inserted
 };
 
 struct Token {
@@ -131,5 +123,4 @@ struct Token {
     }
 };
 
-using TokenStream = std::vector<Token>;
 } // namespace sigil

--- a/projects/sigil/include/sigil/ast/token.hpp
+++ b/projects/sigil/include/sigil/ast/token.hpp
@@ -116,17 +116,18 @@ enum class TokenType : ml::u8 {
 };
 
 struct Token {
-    ml::i32 line;
-    ml::i32 offset;
-    ml::u16 column;
-    ml::u16 length;
+    ml::i32   line;
+    ml::i32   offset;
+    ml::u16   column;
+    ml::u16   length;
     TokenType type;
 
     bool operator==(const Token& other) const {
         return type == other.type
-            && line == other.line
-            && column == other.column
-            && length == other.length;
+               && offset == other.offset
+               && length == other.length
+               && line == other.line
+               && column == other.column;
     }
 };
 

--- a/projects/sigil/include/sigil/ast/token.hpp
+++ b/projects/sigil/include/sigil/ast/token.hpp
@@ -1,15 +1,18 @@
 #pragma once
 
+#include <sigil/core/logger.hpp>
+
 #include <mana/literals.hpp>
 
 #include <magic_enum/magic_enum.hpp>
-#include <sigil/core/logger.hpp>
+
 #include <string>
 #include <vector>
 
 namespace sigil {
 namespace ml = mana::literals;
-enum class TokenType : ml::i64 {
+
+enum class TokenType : ml::u8 {
     Identifier,
 
     Op_Plus,
@@ -109,78 +112,23 @@ enum class TokenType : ml::i64 {
     Eof,
 
     Unknown,
-    _artifact_,  // special token, auto-inserted
-};
-
-struct TextPosition {
-    ml::i64 line;
-    ml::i64 column;
-
-    bool operator==(const TextPosition& other) const {
-        return line == other.line && column == other.column;
-    }
+    _artifact_, // special token, auto-inserted
 };
 
 struct Token {
-    TokenType    type;
-    std::string  text;
-    TextPosition position;
+    ml::i32 line;
+    ml::i32 offset;
+    ml::u16 column;
+    ml::u16 length;
+    TokenType type;
 
     bool operator==(const Token& other) const {
-        return type == other.type && position == other.position && text == other.text;
-    }
-
-    template <typename T>
-    SIGIL_NODISCARD T As() const {
-        static_assert(
-            false,
-            "This function exists to convert literal tokens to actual literals,"
-            " so only its specializations are supported"
-        );
-        return T();
+        return type == other.type
+            && line == other.line
+            && column == other.column
+            && length == other.length;
     }
 };
 
-template <>
-SIGIL_NODISCARD inline auto Token::As<ml::f32>() const -> ml::f32 {
-    return std::stof(text);
-}
-
-template <>
-SIGIL_NODISCARD inline auto Token::As<ml::f64>() const -> ml::f64 {
-    return std::stod(text);
-}
-
-template <>
-SIGIL_NODISCARD inline auto Token::As<ml::i64>() const -> ml::i64 {
-    return std::stoll(text);
-}
-
-template <>
-SIGIL_NODISCARD inline auto Token::As<ml::u64>() const -> ml::u64 {
-    return std::stoull(text);
-}
-
-template <>
-SIGIL_NODISCARD inline bool Token::As<bool>() const {
-    switch (type) {
-    case TokenType::Lit_true:
-        return true;
-    case TokenType::Lit_false:
-        break;
-    default:
-        Log->critical(
-            "Bool conversion requested for non-bool token '{}'. "
-            "Defaulting to 'false'.",
-            magic_enum::enum_name(type)
-        );
-    }
-
-    return false;
-}
-
 using TokenStream = std::vector<Token>;
-
-static const auto TOKEN_EOF = Token {.type = TokenType::Eof, .text = "EOF", .position = {}};
-
-}  // namespace sigil
+} // namespace sigil

--- a/projects/sigil/src/sigil/ast/lexer.cpp
+++ b/projects/sigil/src/sigil/ast/lexer.cpp
@@ -377,7 +377,7 @@ void Lexer::LexUnknown() {
 // we take a string ref because
 // we have a string that we'd otherwise need to construct from a string_view anyway
 bool Lexer::MatchedKeyword(const std::string& identifier_buffer) {
-    if (const auto keyword = keyword_map.find(identifier_buffer);
+    if (const auto keyword = keyword_map.find(identifier_buffer.c_str());
         keyword != keyword_map.end()) {
         AddToken(keyword->second, identifier_buffer.length());
         return true;

--- a/projects/sigil/src/sigil/ast/lexer.cpp
+++ b/projects/sigil/src/sigil/ast/lexer.cpp
@@ -55,10 +55,10 @@ void Lexer::TokenizeLine() {
         LexUnknown();
     }
 
+    ++cursor;
     AddToken(TokenType::Terminator, 1);
 
     ++line_number;
-    ++cursor;
 }
 
 bool Lexer::Tokenize(const std::filesystem::path& file_path) {
@@ -93,14 +93,29 @@ void Lexer::PrintTokens() const {
     Log->debug("--- Printing Token Stream ---\n");
 
     for (const auto& [line, offset, column, length, type] : tokens) {
-        if (type == TokenType::Terminator) {
-            Log->info("[L: {} | C: {}] {}: \\n",
+        // this should be a switch but i'm lazy
+        if (type == TokenType::_artifact_) {
+            Log->info("[{}:{}] Artifact: {}",
+                      line,
+                      column,
+                      Source.Name());
+            continue;
+        }
+        if (type == TokenType::Eof) {
+            Log->info("[{}:{}] {}: EOF",
                       line,
                       column,
                       magic_enum::enum_name(type));
             continue;
         }
-        Log->info("[L: {} | C: {}] {}: {}",
+        if (type == TokenType::Terminator) {
+            Log->info("[{}:{}] {}: \\n",
+                      line,
+                      column,
+                      magic_enum::enum_name(type));
+            continue;
+        }
+        Log->info("[{}:{}] {}: {}",
                   line,
                   column,
                   magic_enum::enum_name(type),

--- a/projects/sigil/src/sigil/ast/lexer.cpp
+++ b/projects/sigil/src/sigil/ast/lexer.cpp
@@ -65,15 +65,6 @@ bool Lexer::Tokenize(const std::filesystem::path& file_path) {
     Reset();
     Source.Load(file_path);
 
-    //TODO: this has to change.
-    tokens.emplace_back(Token{
-        .line = -1,
-        .offset = 0,
-        .column = 0,
-        .length = 0,
-        .type = TokenType::_artifact_,
-    });
-
     // lines count from 1
     line_number = 1;
     while (cursor < Source.Size()) {
@@ -93,14 +84,6 @@ void Lexer::PrintTokens() const {
     Log->debug("--- Printing Token Stream ---\n");
 
     for (const auto& [line, offset, column, length, type] : tokens) {
-        // this should be a switch but i'm lazy
-        if (type == TokenType::_artifact_) {
-            Log->info("[{}:{}] Artifact: {}",
-                      line,
-                      column,
-                      Source.Name());
-            continue;
-        }
         if (type == TokenType::Eof) {
             Log->info("[{}:{}] {}: EOF",
                       line,
@@ -133,7 +116,7 @@ void Lexer::Reset() {
     line_start  = 0;
 }
 
-TokenStream&& Lexer::RelinquishTokens() {
+std::vector<Token>&& Lexer::RelinquishTokens() {
     return std::move(tokens);
 }
 

--- a/projects/sigil/src/sigil/ast/parser.cpp
+++ b/projects/sigil/src/sigil/ast/parser.cpp
@@ -1,13 +1,12 @@
 #include <sigil/ast/parser.hpp>
 #include <sigil/core/logger.hpp>
+#include <sigil/ast/source-file.hpp>
+#include <sigil/ast/syntax-tree.hpp>
 
 #include <magic_enum/magic_enum.hpp>
 
 #include <algorithm>
 #include <fstream>
-#include <sigil/ast/syntax-tree.hpp>
-
-#include "sigil/ast/lexer.hpp"
 
 namespace sigil {
 using namespace ast;
@@ -50,7 +49,7 @@ auto Parser::ViewAST() const -> Node* {
 
 void Parser::PrintParseTree() const {
     Log->debug("Parse tree for artifact '{}'\n\n{}",
-               Lexer::Source.Name(),
+               Source().Name(),
                EmitParseTree(parse_tree));
 }
 
@@ -79,7 +78,7 @@ std::string Parser::EmitParseTree(const ParseNode& node, std::string prepend) co
     if (node.rule == Rule::Artifact) {
         ret = fmt::format("[{}] -> {}\n\n",
                           magic_enum::enum_name(node.rule),
-                          Lexer::Source.Name());
+                          Source().Name());
     }
     else {
         ret.append(fmt::format("{}[{}]\n", prepend, magic_enum::enum_name(node.rule)));
@@ -221,7 +220,7 @@ void Parser::ConstructAST(const ParseNode& node) {
         return;
     }
 
-    syntax_tree = std::make_unique<Artifact>(Lexer::Source.Name());
+    syntax_tree = std::make_unique<Artifact>(Source().Name());
 
     //TODO: this is kind of a bug.
     // instead of adding all statements to 'root',

--- a/projects/sigil/src/sigil/ast/source-file.cpp
+++ b/projects/sigil/src/sigil/ast/source-file.cpp
@@ -1,4 +1,9 @@
 #include <sigil/ast/source-file.hpp>
+#include <sigil/ast/lexer.hpp>
+#include <sigil/core/logger.hpp>
+#include <sigil/ast/token.hpp>
+
+#include <fstream>
 
 namespace sigil {
 bool GlobalSourceFile::Load(const std::filesystem::path& file_path) {
@@ -45,5 +50,13 @@ uintmax_t GlobalSourceFile::Size() const {
 
 char GlobalSourceFile::operator[](const std::size_t index) const {
     return contents[index];
+}
+
+SIGIL_NODISCARD const GlobalSourceFile& Source() {
+    return Lexer::Source;
+}
+
+SIGIL_NODISCARD std::string_view FetchTokenText(const Token token) {
+    return Lexer::Source.Slice(token.offset, token.length);
 }
 } // namespace sigil

--- a/projects/sigil/src/sigil/ast/source-file.cpp
+++ b/projects/sigil/src/sigil/ast/source-file.cpp
@@ -1,0 +1,47 @@
+#include <sigil/ast/source-file.hpp>
+
+namespace sigil {
+bool GlobalSourceFile::Load(const std::filesystem::path& file_path) {
+    std::ifstream source_file(file_path);
+    if (not source_file.is_open()) {
+        Log->error("Failed to open file at '{}'", file_path.string());
+        return false;
+    }
+
+    size = std::filesystem::file_size(file_path);
+    contents.resize(size);
+    source_file.read(contents.data(), size);
+    source_file.close();
+
+    name = file_path.filename().replace_extension("").string();
+
+    view = contents;
+
+    return true;
+}
+
+void GlobalSourceFile::Reset() {
+    contents.clear();
+    name.clear();
+}
+
+std::string_view GlobalSourceFile::Name() const {
+    return name;
+}
+
+std::string_view GlobalSourceFile::Content() const {
+    return contents;
+}
+
+std::string_view GlobalSourceFile::Slice(const std::size_t start, const std::size_t length) const {
+    return view.substr(start, length);
+}
+
+uintmax_t GlobalSourceFile::Size() const {
+    return size;
+}
+
+char GlobalSourceFile::operator[](const std::size_t index) const {
+    return contents[index];
+}
+} // namespace sigil

--- a/projects/sigil/src/sigil/ast/source-file.cpp
+++ b/projects/sigil/src/sigil/ast/source-file.cpp
@@ -23,6 +23,8 @@ bool GlobalSourceFile::Load(const std::filesystem::path& file_path) {
 void GlobalSourceFile::Reset() {
     contents.clear();
     name.clear();
+    view = {};
+    size = 0;
 }
 
 std::string_view GlobalSourceFile::Name() const {

--- a/projects/sigil/src/sigil/ast/syntax-tree.cpp
+++ b/projects/sigil/src/sigil/ast/syntax-tree.cpp
@@ -6,6 +6,8 @@
 
 #include <mana/vm/primitive-type.hpp>
 
+#include <magic_enum/magic_enum.hpp>
+
 namespace sigil::ast {
 using namespace mana::literals;
 

--- a/projects/sigil/src/sigil/ast/syntax-tree.cpp
+++ b/projects/sigil/src/sigil/ast/syntax-tree.cpp
@@ -37,7 +37,7 @@ auto MakeNullLiteral() {
 }
 
 struct LiteralData {
-    Node::Ptr           value;
+    NodePtr           value;
     mana::PrimitiveType type;
 };
 
@@ -71,7 +71,7 @@ auto Artifact::GetName() const -> std::string_view {
     return name;
 }
 
-auto Artifact::GetChildren() const -> const std::vector<Ptr>& {
+auto Artifact::GetChildren() const -> const std::vector<NodePtr>& {
     return children;
 }
 
@@ -80,7 +80,7 @@ void Artifact::Accept(Visitor& visitor) const {
 }
 
 /// Statement
-Statement::Statement(const Ptr&& node)
+Statement::Statement(const NodePtr&& node)
     : child(std::move(node)) {}
 
 void Statement::Accept(Visitor& visitor) const {
@@ -105,7 +105,7 @@ ArrayLiteral::ArrayLiteral(const ParseNode& node)
     }
 }
 
-Node::Ptr ArrayLiteral::ProcessValue(const ParseNode& elem) {
+NodePtr ArrayLiteral::ProcessValue(const ParseNode& elem) {
     switch (elem.rule) {
         using enum Rule;
 
@@ -176,7 +176,7 @@ Node::Ptr ArrayLiteral::ProcessValue(const ParseNode& elem) {
     }
 }
 
-const std::vector<Node::Ptr>& ArrayLiteral::GetValues() const {
+const std::vector<NodePtr>& ArrayLiteral::GetValues() const {
     return values;
 }
 
@@ -247,7 +247,7 @@ SIGIL_NODISCARD bool IsBooleanLiteral(const TokenType token) {
     return token == Lit_true || token == Lit_false;
 }
 
-Node::Ptr BinaryExpr::ConstructChild(const ParseNode& operand_node) {
+NodePtr BinaryExpr::ConstructChild(const ParseNode& operand_node) {
     const auto& token = operand_node.tokens[0];
     switch (operand_node.rule) {
         using enum Rule;

--- a/projects/sigil/src/sigil/ast/syntax-tree.cpp
+++ b/projects/sigil/src/sigil/ast/syntax-tree.cpp
@@ -1,8 +1,8 @@
-#include <sigil/core/logger.hpp>
-#include <sigil/ast/parse-tree.hpp>
 #include <sigil/ast/syntax-tree.hpp>
+#include <sigil/ast/parse-tree.hpp>
+#include <sigil/ast/source-file.hpp>
 #include <sigil/ast/visitor.hpp>
-#include <sigil/ast/lexer.hpp>
+#include <sigil/core/logger.hpp>
 
 #include <mana/vm/primitive-type.hpp>
 

--- a/projects/sigil/tests/tests/ptree.cpp
+++ b/projects/sigil/tests/tests/ptree.cpp
@@ -33,7 +33,7 @@ TEST_CASE("P-Trees", "[parse][ast]") {
             REQUIRE(tokens[0].type == TokenType::_artifact_);
             CHECK_FALSE(ptree.tokens.empty());
             REQUIRE(ptree.rule == Rule::Artifact);
-            REQUIRE(ptree.tokens[0].text == "expressions");
+            REQUIRE(FetchTokenText(ptree.tokens[0]) == "expressions");
         }
 
         SECTION("P-Tree output matches control") {

--- a/projects/sigil/tests/tests/ptree.cpp
+++ b/projects/sigil/tests/tests/ptree.cpp
@@ -25,7 +25,7 @@ TEST_CASE("P-Trees", "[parse][ast]") {
 
         REQUIRE(parser.Parse());
 
-        const auto& tokens = parser.ViewTokens();
+        const auto& tokens = parser.ViewTokenStream();
         const auto& ptree  = parser.ViewParseTree();
 
         SECTION("Root is properly formed") {


### PR DESCRIPTION
Tokens now no longer store their text as strings, but instead an offset into a global, read-only source file.

This source file is thread local, allowing lexers on different threads to manage exactly one source file per thread.

Only the Lexer can modify the global source file, and it will only do so when loading in a new file to lex. GlobalSourceFile is generally left untouched for reading only.

This may not be the optimal multithreading solution, but at least it will prevent anything from breaking for now.