### PR TITLE
Switch to register-based bytecode

### DIFF
--- a/projects/circe/include/circe/main-visitor.hpp
+++ b/projects/circe/include/circe/main-visitor.hpp
@@ -11,36 +11,60 @@ namespace ml = mana::literals;
 namespace mv = mana::vm;
 namespace ast = sigil::ast;
 
-class MainVisitor final : public ast::Visitor {
-    using SymbolTable = std::unordered_map<std::string, ml::u16>;
+class CirceVisitor final : public ast::Visitor {
+    struct Symbol {
+        ml::u16 register_index;
+        ml::u16 scope_depth;
+    };
+    using SymbolTable = std::unordered_map<std::string, Symbol>;
 
     mv::Slice   slice;
     SymbolTable symbols;
-    ml::u16     next_slot = {};
+    ml::u16     total_registers;
+    ml::u16     scope_depth;
 
-    std::vector<ml::u16> reg_stack;
+    std::vector<ml::u16> reg_buffer;
+    std::vector<ml::u16> free_regs;
 
 public:
+    CirceVisitor();
+
     CIRCE_NODISCARD mv::Slice GetSlice() const;
-    CIRCE_NODISCARD ml::u64   ComputeJumpDist(ml::u64 index) const;
+
+    void Visit(const ast::Artifact& artifact) override;
 
     void Visit(const ast::UnaryExpr& node) override;
-    void Visit(const ast::Artifact& artifact) override;
     void Visit(const ast::BinaryExpr& node) override;
+
+    void Visit(const ast::Statement& node) override;
+    void Visit(const ast::Scope& node) override;
+    void Visit(const ast::DataDeclaration& node) override;
+    void Visit(const ast::Identifier& node) override;
+
+    void Visit(const ast::If& node) override;
+
     void Visit(const ast::Literal<ml::f64>& literal) override;
     void Visit(const ast::Literal<ml::i64>& literal) override;
     void Visit(const ast::Literal<void>& node) override;
     void Visit(const ast::Literal<bool>& literal) override;
     void Visit(const ast::ArrayLiteral& array) override;
-    void Visit(const ast::Statement& node) override;
-    void Visit(const ast::Scope& node) override;
-    void Visit(const ast::If& node) override;
-    void Visit(const ast::DataDeclaration& node) override;
-    void Visit(const ast::Identifier& node) override;
+
 
 private:
     ml::u16 AllocateRegister();
-    ml::u16 PopRegStack();
+    void FreeRegister(ml::u16 reg);
+    void FreeRegisters(std::initializer_list<ml::u16> regs);
+    void FreeRegisters(const std::vector<ml::u16>& regs);
+
+    bool RegisterIsOwned(ml::u16 reg);
+
+    ml::u16 PopRegBuffer();
+    void ClearRegBuffer();
+
+    void CleanupCurrentScope();
+
+    void AddSymbol(const std::string& name, ml::u16 register_index);
+    void RemoveSymbol(const std::string& name);
 
     template <typename T>
     void CreateLiteral(const ast::Literal<T>& literal) {
@@ -48,7 +72,7 @@ private:
         ml::u16 idx = slice.AddConstant(literal.Get());
         slice.Write(mv::Op::LoadConstant, {dst, idx});
 
-        reg_stack.push_back(dst);
+        reg_buffer.push_back(dst);
     }
 };
 } // namespace circe

--- a/projects/circe/src/circe/main-visitor.cpp
+++ b/projects/circe/src/circe/main-visitor.cpp
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include <ranges>
+
 #include <circe/core/logger.hpp>
 #include <circe/main-visitor.hpp>
 
@@ -9,57 +12,76 @@ namespace circe {
 using namespace mana::vm;
 using namespace sigil::ast;
 
-Slice MainVisitor::GetSlice() const {
+CirceVisitor::CirceVisitor()
+    : total_registers {}
+    , scope_depth {} {}
+
+Slice CirceVisitor::GetSlice() const {
     return slice;
 }
 
-u64 MainVisitor::ComputeJumpDist(const u64 index) const {
-    constexpr u64 payload_bytes = 2;
-
-    u64 dist = slice.BackIndex() - index - payload_bytes;
-    if (dist > std::numeric_limits<u16>::max()) {
-        Log->error("Jump distance '{}' exceeded maximum jump size of {}",
-                   dist,
-                   std::numeric_limits<u16>::max()
-        );
-        dist = 0;
-    }
-
-    return dist;
-}
-
-void MainVisitor::Visit(const Artifact& artifact) {
+void CirceVisitor::Visit(const Artifact& artifact) {
     for (const auto& statement : artifact.GetChildren()) {
         statement->Accept(*this);
 
         // prevent dangling register references
-        reg_stack.clear();
+        ClearRegBuffer();
     }
     slice.Write(Op::Halt);
 }
 
-constexpr u8 CJMP_OP_BYTES = 5;
-constexpr u8 JMP_OP_BYTES = 3;
+void CirceVisitor::Visit(const UnaryExpr& node) {
+    node.GetVal().Accept(*this);
 
-void MainVisitor::Visit(const BinaryExpr& node) {
+    if (node.GetOp().size() > 1) {
+        Log->error("Unhandled unary expression");
+        return;
+    }
+
+    u16 src = PopRegBuffer();
+    u16 dst = AllocateRegister();
+
+    Op op;
+    switch (node.GetOp()[0]) {
+    case '-':
+        op = Op::Negate;
+        break;
+    case '!':
+        op = Op::Not;
+        break;
+    default:
+        Log->error("Invalid unary expression");
+        FreeRegister(src);
+        FreeRegister(PopRegBuffer());
+        return;
+    }
+
+    slice.Write(op, {dst, src});
+    reg_buffer.push_back(dst);
+    FreeRegister(src);
+}
+
+void CirceVisitor::Visit(const BinaryExpr& node) {
     const auto op_str = node.GetOp();
 
     // logical ops need special treatment as they are control flow due to short-circuiting
     const auto jump = [this, &node](const Op jump_op) {
         node.GetLeft().Accept(*this);
 
-        const u16 lhs = PopRegStack();
+        const u16 lhs = PopRegBuffer();
         const u16 dst = AllocateRegister();
         slice.Write(Op::Move, {dst, lhs});
 
         const u64 jwf = slice.Write(jump_op, {lhs, 0xDEAD});
+        FreeRegister(lhs);
 
         node.GetRight().Accept(*this);
-        const u16 rhs = PopRegStack();
+        const u16 rhs = PopRegBuffer();
         slice.Write(Op::Move, {dst, rhs});
 
         slice.Patch(jwf, slice.Instructions().size() - (jwf + CJMP_OP_BYTES), 1);
-        reg_stack.push_back(dst);
+        reg_buffer.push_back(dst);
+        FreeRegister(rhs);
     };
 
 
@@ -76,8 +98,8 @@ void MainVisitor::Visit(const BinaryExpr& node) {
     node.GetLeft().Accept(*this);
     node.GetRight().Accept(*this);
 
-    u16 rhs = PopRegStack();
-    u16 lhs = PopRegStack();
+    u16 rhs = PopRegBuffer();
+    u16 lhs = PopRegBuffer();
     u16 dst = AllocateRegister();
 
     Op op;
@@ -113,63 +135,78 @@ void MainVisitor::Visit(const BinaryExpr& node) {
             op = Op::Equals;
             break;
         }
+        FreeRegisters({lhs, rhs});
         return; // prevent accidental fallthrough
     case '!':
         if (op_str.size() == 2 && op_str[1] == '=') {
             op = Op::NotEquals;
             break;
         }
+        FreeRegisters({lhs, rhs});
         return;
     default:
         Log->error("Unknown Binary Operator '{}'", node.GetOp());
+        FreeRegisters({lhs, rhs});
         return;
     }
 
     slice.Write(op, {dst, lhs, rhs});
-    reg_stack.push_back(dst);
+    reg_buffer.push_back(dst);
+    FreeRegisters({lhs, rhs});
 }
 
-void MainVisitor::Visit(const Literal<f64>& literal) {
-    CreateLiteral(literal);
+void CirceVisitor::Visit(const Statement& node) {
+    Log->error("Statement nodes should forward their visit to their child node(s).");
 }
 
-void MainVisitor::Visit(const Literal<i64>& literal) {
-    CreateLiteral(literal);
-}
-
-void MainVisitor::Visit(const Literal<bool>& literal) {
-    CreateLiteral(literal);
-}
-
-void MainVisitor::Visit(const Literal<void>& node) {}
-
-void MainVisitor::Visit(const ArrayLiteral& array) {
-    const auto& array_elems = array.GetValues();
-    if (array_elems.empty()) return;
-
-    // for now we just index arrays as separate values
-    // eventually we'll need a way to tell the VM to construct an array from all these sequential constants
-    for (const auto& val : array_elems) {
-        val->Accept(*this);
+void CirceVisitor::Visit(const Scope& node) {
+    ++scope_depth;
+    for (const auto& statement : node.GetStatements()) {
+        statement->Accept(*this);
+        ClearRegBuffer();
     }
 
-    // TODO: add 'MakeArray' opcode to VM
+    CleanupCurrentScope();
+    --scope_depth;
 }
 
-void MainVisitor::Visit(const Statement& node) {
-    node.Accept(*this);
-    //Log->error("Statement nodes should probably not be in the AST");
+void CirceVisitor::Visit(const DataDeclaration& node) {
+    const std::string name(node.GetName());
+    if (symbols.contains(name)) {
+        Log->error("Redefinition of '{}'", name);
+        return;
+    }
+
+    u16 datum;
+
+    if (const auto& init = node.GetInitializer()) {
+        init->Accept(*this);
+        datum = PopRegBuffer();
+    } else {
+        datum = AllocateRegister();
+        slice.Write(Op::LoadConstant, {datum, slice.AddConstant(0.0)});
+    }
+
+    AddSymbol(name, datum);
 }
 
-void MainVisitor::Visit(const Scope& node) {
-    node.Accept(*this);
+void CirceVisitor::Visit(const Identifier& node) {
+    const std::string name(node.GetName());
+    if (const auto it = symbols.find(name); it != symbols.end()) {
+        reg_buffer.push_back(it->second.register_index);
+        return;
+    }
+
+    Log->warn("Undefined identifier '{}'", name);
+    slice.Write(Op::Halt);
 }
 
-void MainVisitor::Visit(const If& node) {
+void CirceVisitor::Visit(const If& node) {
     node.GetCondition()->Accept(*this);
-    const u16 cond_reg = PopRegStack();
+    const u16 cond_reg = PopRegBuffer();
 
     const u64 jmp_false = slice.Write(Op::JumpWhenFalse, {cond_reg, 0xDEAD});
+    FreeRegister(cond_reg);
 
     node.GetThenBlock()->Accept(*this);
 
@@ -186,79 +223,115 @@ void MainVisitor::Visit(const If& node) {
     }
 }
 
-void MainVisitor::Visit(const DataDeclaration& node) {
-    const std::string name(node.GetName());
-    if (symbols.contains(name)) {
-        Log->error("Redefinition of '{}'", name);
-        return;
-    }
-
-    u16 datum;
-
-    if (const auto& init = node.GetInitializer()) {
-        init->Accept(*this);
-        datum = PopRegStack();
-    } else {
-        datum = AllocateRegister();
-        slice.Write(Op::LoadConstant, {datum, slice.AddConstant(0.0)});
-    }
-
-    symbols[name] = datum;
+void CirceVisitor::Visit(const Literal<f64>& literal) {
+    CreateLiteral(literal);
 }
 
-void MainVisitor::Visit(const Identifier& node) {
-    const std::string name(node.GetName());
-    if (const auto it = symbols.find(name); it != symbols.end()) {
-        reg_stack.push_back(it->second);
-        return;
-    }
-
-    Log->warn("Undefined identifier '{}'", name);
-    reg_stack.push_back(0);
+void CirceVisitor::Visit(const Literal<i64>& literal) {
+    CreateLiteral(literal);
 }
 
-u16 MainVisitor::AllocateRegister() {
-    return next_slot++;
+void CirceVisitor::Visit(const Literal<void>& node) {}
+
+void CirceVisitor::Visit(const Literal<bool>& literal) {
+    CreateLiteral(literal);
 }
 
-u16 MainVisitor::PopRegStack() {
-    if (reg_stack.empty()) {
-        Log->error("Internal Compiler Error: Register stack underflow");
-        return 0;
+void CirceVisitor::Visit(const ArrayLiteral& array) {
+    const auto& array_elems = array.GetValues();
+    if (array_elems.empty()) return;
+
+    // for now we just index arrays as separate values
+    // eventually we'll need a way to tell the VM to construct an array from all these sequential constants
+    for (const auto& val : array_elems) {
+        val->Accept(*this);
     }
 
-    const u16 slot = reg_stack.back();
-    reg_stack.pop_back();
+    // TODO: add 'MakeArray' opcode to VM
+}
+
+u16 CirceVisitor::AllocateRegister() {
+    if (free_regs.empty()) {
+        return total_registers++;
+    }
+
+    const u16 slot = free_regs.back();
+    free_regs.pop_back();
 
     return slot;
 }
 
-void MainVisitor::Visit(const UnaryExpr& node) {
-    node.GetVal().Accept(*this);
+void CirceVisitor::FreeRegister(u16 reg) {
+    if (not RegisterIsOwned(reg)) {
+        free_regs.push_back(reg);
+    }
+}
 
-    if (node.GetOp().size() > 1) {
-        Log->error("Unhandled unary expression");
+void CirceVisitor::FreeRegisters(std::initializer_list<u16> regs) {
+    for (const auto reg : regs) {
+        FreeRegister(reg);
+    }
+}
+
+void CirceVisitor::FreeRegisters(const std::vector<u16>& regs) {
+    for (const auto reg : regs) {
+        FreeRegister(reg);
+    }
+}
+
+bool CirceVisitor::RegisterIsOwned(u16 reg) {
+    for (const auto& val : std::views::values(symbols)) { // NOLINT(*-use-anyofallof)
+        if (val.register_index == reg) {
+            return true;
+        }
+    }
+    return false;
+}
+
+u16 CirceVisitor::PopRegBuffer() {
+    if (reg_buffer.empty()) {
+        Log->error("Internal Compiler Error: Register stack underflow");
+        return 0;
+    }
+
+    const u16 slot = reg_buffer.back();
+    reg_buffer.pop_back();
+
+    return slot;
+}
+
+void CirceVisitor::ClearRegBuffer() {
+    FreeRegisters(reg_buffer);
+    reg_buffer.clear();
+}
+
+void CirceVisitor::CleanupCurrentScope() {
+    std::vector<std::string> to_remove;
+    for (const auto& [name, symbol] : symbols) {
+        if (symbol.scope_depth == scope_depth) {
+            // delegate removal to avoid iterator invalidation
+            to_remove.push_back(name);
+        }
+    }
+
+    for (const auto& name : to_remove) {
+        RemoveSymbol(name);
+    }
+}
+
+void CirceVisitor::AddSymbol(const std::string& name, u16 register_index) {
+    symbols[name] = {register_index, scope_depth};
+}
+
+void CirceVisitor::RemoveSymbol(const std::string& name) {
+    if (not symbols.contains(name)) {
+        Log->warn("Attempted to remove non-existent symbol '{}'", name);
         return;
     }
 
-    u16 src = PopRegStack();
-    u16 dst = AllocateRegister();
-
-    Op op;
-    switch (node.GetOp()[0]) {
-    case '-':
-        op = Op::Negate;
-        break;
-    case '!':
-        op = Op::Not;
-        break;
-    default:
-        Log->error("Invalid unary expression");
-        PopRegStack();
-        return;
-    }
-
-    slice.Write(op, {dst, src});
-    reg_stack.push_back(dst);
+    // prevent duplicate entries in e.g. 'data x = y'
+    u16 reg = symbols[name].register_index;
+    symbols.erase(name);
+    FreeRegister(reg);
 }
 } // namespace circe

--- a/projects/circe/src/circe/main.cpp
+++ b/projects/circe/src/circe/main.cpp
@@ -36,7 +36,7 @@ int CompileFrom(const std::string& filename) {
     Log->info("Compiling...");
     parser.PrintParseTree();
 
-    MainVisitor visitor;
+    CirceVisitor visitor;
     ast->Accept(visitor);
 
     mana::vm::Slice slice;

--- a/projects/hex/include/hex/core/disassembly.hpp
+++ b/projects/hex/include/hex/core/disassembly.hpp
@@ -8,16 +8,10 @@
 namespace hex {
 namespace ml = mana::literals;
 
-void EmitConstant(ml::i64 offset, mana::vm::Op op, ml::f64 constant);
-void EmitConstant(ml::i64 offset, mana::vm::Op op, ml::u64 constant);
-void EmitConstant(ml::i64 offset, bool constant);
-
-void EmitSimple(ml::i64 offset, mana::vm::Op op);
-
-void EmitJump(ml::i64 offset, mana::vm::Op op, ml::u16 distance);
-
-void EmitPayload(ml::i64 offset, mana::vm::Op op, ml::u16 payload);
-
-void PrintBytecode(const mana::vm::Slice& c);
+/**
+ * @brief Prints the register-based bytecode in a human-readable format.
+ * Matches the new 3-address instruction set (Dst, L, R).
+ */
+void PrintBytecode(const mana::vm::Slice& s);
 
 }  // namespace hex

--- a/projects/hex/include/hex/vm/virtual-machine.hpp
+++ b/projects/hex/include/hex/vm/virtual-machine.hpp
@@ -16,29 +16,12 @@ enum class InterpretResult {
 class VirtualMachine {
     ml::u8* ip {nullptr};
 
-    std::vector<mvm::Value> locals;
-    std::vector<mvm::Value> stack;
-    mvm::Value*             stack_top;
+    std::vector<mvm::Value> registers;
 
 public:
     VirtualMachine();
 
     InterpretResult Interpret(mvm::Slice* next_slice);
-
-    HEX_NODISCARD ml::u64 StackSize() const;
-
-private:
-    void Reset();
-
-    void       Push(const mvm::Value& value);
-    mvm::Value Pop();
-
-    HEX_NODISCARD mvm::Value ViewTop() const;
-    HEX_NODISCARD mvm::Value* StackTop() const;
-
-    void LogTop(std::string_view msg) const;
-    void LogTopTwo(std::string_view msg) const;
-    void LogLocalDatum(std::string_view msg) const;
 };
 
 }  // namespace hex

--- a/projects/hex/src/hex/core/disassembly.cpp
+++ b/projects/hex/src/hex/core/disassembly.cpp
@@ -111,7 +111,7 @@ void PrintBytecode(const Slice& s) {
         case JumpWhenFalse: {
             const u16 reg  = read();
             const u16 dist = read();
-            // Offset + Opcode (1) + Reg (2) + Dist (2) + Distance
+            // Offset + Opcode (1) + Reg (2) + Destination (2)
             Log->debug("{:04} | {} R{} => {:04}", offset, name, reg, offset + 5 + dist);
             break;
         }

--- a/projects/hex/src/hex/core/disassembly.cpp
+++ b/projects/hex/src/hex/core/disassembly.cpp
@@ -48,7 +48,7 @@ void PrintBytecode(const Slice& s) {
             const auto& val = s.Constants()[idx];
 
             const auto log_val = [&](auto v) {
-                Log->debug("{:04} | {} R{} <= {} (idx: {})", offset, name, reg, v, idx);
+                Log->debug("{:04} | {} R{} <- {} [constant index: {}]", offset, name, reg, v, idx);
             };
 
             switch (val.GetType()) {
@@ -71,6 +71,15 @@ void PrintBytecode(const Slice& s) {
                 log_val("???");
                 break;
             }
+            break;
+        }
+
+        case Move:
+        case Negate:
+        case Not: {
+            const u16 dst = read();
+            const u16 src = read();
+            Log->debug("{:04} | {} R{}, R{}", offset, name, dst, src);
             break;
         }
 

--- a/projects/hex/src/hex/core/disassembly.cpp
+++ b/projects/hex/src/hex/core/disassembly.cpp
@@ -6,108 +6,109 @@
 namespace hex {
 using namespace mana::vm;
 
-void EmitConstant(i64 offset, Op op, f64 constant) {
-    Log->debug("{:04} | {} => {}", offset, magic_enum::enum_name(op), constant);
+/**
+ * @brief Reads a 16-bit little-endian payload from the bytecode.
+ */
+static u16 ReadPayload(const u8 first_byte, const u8 second_byte) {
+    return static_cast<u16>(first_byte | (second_byte << 8));
 }
 
-void EmitJump(i64 offset, Op op, u16 distance) {
-    constexpr u16 num_jmp_instructions = 3;
-    Log->debug("{:04} | {} => {:04}",
-               offset,
-               magic_enum::enum_name(op),
-               offset + num_jmp_instructions + distance
-    );
-}
-
-void EmitPayload(i64 offset, Op op, u16 payload) {
-    Log->debug("{:04} | {}: {}",
-               offset,
-               magic_enum::enum_name(op),
-               payload
-    );
-}
-
-void EmitConstant(const i64 offset, const Op op, const Value& constant) {
-    const auto print = [offset, op]<typename T>(const mana::PrimitiveType type, T val) {
-        if (Op::Push == op) {
-            Log->debug("{:04} | {} | {} | {}",
-                       offset,
-                       magic_enum::enum_name(op),
-                       magic_enum::enum_name(type), val);
-
-            return;
-        }
-
-        Log->debug("{:04} | {} => {}", offset, magic_enum::enum_name(op), val);
-    };
-
-    switch (constant.GetType()) {
-    case mana::PrimitiveType::Float64:
-        print(constant.GetType(), constant.AsFloat());
-        break;
-    case mana::PrimitiveType::Int64:
-        print(constant.GetType(), constant.AsInt());
-        break;
-    case mana::PrimitiveType::Uint64:
-        print(constant.GetType(), constant.AsUint());
-        break;
-    case mana::PrimitiveType::Bool:
-        print(constant.GetType(), constant.AsBool());
-        break;
-    default:
-        break;
-    }
-}
-
-u16 ReadPayload(const u8 first_byte, const u8 second_byte) {
-    const auto ret = static_cast<u16>(first_byte | second_byte << 8);
-    return ret;
-}
-
-void EmitSimple(i64 offset, const Op op) {
-    Log->debug("{:04} | {}", offset, magic_enum::enum_name(op));
-}
-
-void PrintBytecode(const Slice& c) {
-    const auto& code = c.Instructions();
+void PrintBytecode(const Slice& s) {
+    const auto& code = s.Instructions();
 
     for (i64 i = 0; i < code.size(); ++i) {
-        switch (const auto op = static_cast<Op>(code[i])) {
+        const i64  offset = i;
+        const auto op     = static_cast<Op>(code[i]);
+        const auto name   = magic_enum::enum_name(op);
+
+        // Helper to read 2-byte payloads and advance the loop counter
+        auto read = [&] {
+            u16 val = ReadPayload(code[i + 1], code[i + 2]);
+
+            i += 2;
+            return val;
+        };
+
+        switch (op) {
             using enum Op;
-        case Push:
-            EmitConstant(i, op, c.Constants()[ReadPayload(code[i + 1], code[i + 2])]);
-            i += 2;
+        case Halt:
+            Log->debug("{:04} | {}", offset, name);
             break;
-        case JumpWhenFalse:
-        case JumpWhenTrue:
-        case Jump:
-            EmitJump(i, op, ReadPayload(code[i + 1], code[i + 2]));
-            i += 2;
+
+        case Return: {
+            const u16 reg = read();
+            Log->debug("{:04} | {} R{}", offset, name, reg);
             break;
-        case Load:
-        case Store:
-            EmitPayload(i, op, ReadPayload(code[i + 1], code[i + 2]));
-            i += 2;
+        }
+
+
+        case LoadConstant: {
+            const u16   reg = read();
+            const u16   idx = read();
+            const auto& val = s.Constants()[idx];
+
+            const auto log_val = [&](auto v) {
+                Log->debug("{:04} | {} R{} <= {} (idx: {})", offset, name, reg, v, idx);
+            };
+
+            switch (val.GetType()) {
+            case mana::PrimitiveType::Float64:
+                log_val(val.AsFloat());
+                break;
+            case mana::PrimitiveType::Int64:
+                log_val(val.AsInt());
+                break;
+            case mana::PrimitiveType::Uint64:
+                log_val(val.AsUint());
+                break;
+            case mana::PrimitiveType::Bool:
+                log_val(val.AsBool());
+                break;
+            case mana::PrimitiveType::None:
+                log_val("none");
+                break;
+            default:
+                log_val("???");
+                break;
+            }
             break;
-        case Pop:
-        case Negate:
+        }
+
         case Add:
         case Sub:
         case Div:
         case Mul:
-        case Halt:
-        case Return:
         case Cmp_Greater:
-        case Cmp_Lesser:
         case Cmp_GreaterEq:
+        case Cmp_Lesser:
         case Cmp_LesserEq:
         case Equals:
-        case NotEquals:
-        case Not:
-            EmitSimple(i, op);
+        case NotEquals: {
+            const u16 dst = read();
+            const u16 lhs = read();
+            const u16 rhs = read();
+            Log->debug("{:04} | {} R{}, R{}, R{}", offset, name, dst, lhs, rhs);
             break;
+        }
+
+        case Jump: {
+            const u16 dist = read();
+            // Offset + Opcode (1) + Payload (2) + Distance
+            Log->debug("{:04} | {} => {:04}", offset, name, offset + 3 + dist);
+            break;
+        }
+
+        case JumpWhenTrue:
+        case JumpWhenFalse: {
+            const u16 reg  = read();
+            const u16 dist = read();
+            // Offset + Opcode (1) + Reg (2) + Dist (2) + Distance
+            Log->debug("{:04} | {} R{} => {:04}", offset, name, reg, offset + 5 + dist);
+            break;
+        }
+
         default:
-            Log->debug("???");
+            Log->debug("{:04} | ??? ({})", offset, static_cast<u8>(op));
             break;
         }
     }

--- a/projects/hex/src/hex/main.cpp
+++ b/projects/hex/src/hex/main.cpp
@@ -67,7 +67,6 @@ void ExecuteVM(const std::string_view exe_name) {
         elapsed_deser.str(),
         elapsed_exec.str()
     );
-    Log->debug("Stack size: {}", vm.StackSize());
 }
 
 int main(const int argc, char** argv) {

--- a/projects/hex/src/hex/vm/virtual-machine.cpp
+++ b/projects/hex/src/hex/vm/virtual-machine.cpp
@@ -6,57 +6,16 @@
 namespace hex {
 using namespace mana::vm;
 
-static constexpr std::size_t STACK_MAX = 512;
-
-// @formatter:off
+static constexpr std::size_t BASE_REG_SIZE = 32;
 
 // payloads are little endian
 #define READ_PAYLOAD (static_cast<u16>(*ip | *(ip + 1) << 8))
 
-// jwf inverts the bool output to avoid needing a branch in the vm
-// this way falsey multiplies by 1, and truthy multiplies by 0
-#define JWF_DIST (READ_PAYLOAD * (((stack_top - 1)->AsBool() - 1) * -1))
-#define JWT_DIST (READ_PAYLOAD * (stack_top - 1)->AsBool())
-
-#ifdef HEX_DEBUG
-#   define DISPATCH()                                                               \
-    {                                                                               \
-        auto  label = *ip >= 0 && *ip < dispatch_max ? dispatch_table[*ip++] : err; \
-        goto *label;                                                                \
-    }
-#   define PUSH(val) Push(val)
-#   define POP() Pop()
-#   define TOP_VAL() *StackTop()
-#   define LOG(msg) Log->debug(msg)
-#   define LOG_JMP(msg, dist) Log->debug(msg, dist)
-#   define LOG_TOP(msg) LogTop(msg)
-#   define LOG_TOP_TWO(msg) LogTopTwo(msg)
-#   define LOG_DATUM(msg) LogLocalDatum(msg)
-#   define FETCH_CONSTANT() constants[READ_PAYLOAD]
-            // use a lambda to guarantee evaluation order
-#   define CMP(op) [&]{auto r = Pop(); auto l = Pop(); return l op r;}()
-#   define LOGICAL_NOT() Push(!Pop())
-#else
-#   define DISPATCH() goto* dispatch_table[*ip++]
-#   define PUSH(val) *(stack_top++) = val
-#   define POP() *(--stack_top)
-#   define TOP_VAL() *(stack_top - 1)
-#   define LOG(msg)
-#   define LOG_JMP(msg, dist)
-#   define LOG_TOP(msg)
-#   define LOG_TOP_TWO(msg)
-#   define LOG_DATUM(msg)
-#   define FETCH_CONSTANT() *(constants + READ_PAYLOAD)
-#   define CMP(op) (stack_top -= 2, *(stack_top) op *(stack_top + 1))
-#   define LOGICAL_NOT() TOP_VAL() = !TOP_VAL();
-#endif
-// @formatter:on
+#define NEXT_PAYLOAD (ip += 2, (static_cast<u16>(*(ip - 2) | *(ip - 1) << 8)))
+#define REG(idx) registers[idx]
 
 VirtualMachine::VirtualMachine() {
-    stack.resize(STACK_MAX);
-    stack_top = stack.data();
-
-    locals.resize(32);
+    registers.resize(BASE_REG_SIZE);
 }
 
 InterpretResult VirtualMachine::Interpret(Slice* slice) {
@@ -64,36 +23,45 @@ InterpretResult VirtualMachine::Interpret(Slice* slice) {
 
     const auto* constants = slice->Constants().data();
 
-    constexpr std::array dispatch_table{
+    // this is for computed goto
+    // it's important to note this list's order is rigid
+    // it must /exactly/ match the opcode enum order
+    constexpr std::array dispatch_table {
         &&halt,
         &&ret,
-        &&push,
-        &&pop,
-        &&load,
-        &&store,
-        &&negate,
+        &&load_constant,
+        &&move,
         &&add,
         &&sub,
         &&div,
         &&mul,
+        &&negate,
+        &&bool_not,
         &&cmp_greater,
         &&cmp_greater_eq,
         &&cmp_lesser,
         &&cmp_lesser_eq,
         &&equals,
         &&not_equals,
-        &&bool_not,
         &&jmp,
-        &&jwf,
-        &&jwt,
+        &&jmp_true,
+        &&jmp_false,
     };
 
 #ifdef HEX_DEBUG
+#   define DISPATCH()                                                   \
+    {                                                                   \
+        auto  label = *ip < dispatch_max ? dispatch_table[*ip++] : err; \
+        goto *label;                                                    \
+    }
+
     constexpr auto err          = &&compile_error;
     constexpr auto dispatch_max = dispatch_table.size();
+#else
+    // we do no bounds checking whatsoever in release
+#   define DISPATCH() goto *dispatch_table[*ip++]
 #endif
 
-    constexpr auto payload_size = 2;
 
     // Start VM
     DISPATCH();
@@ -101,218 +69,129 @@ InterpretResult VirtualMachine::Interpret(Slice* slice) {
 halt:
     return InterpretResult::OK;
 
-ret:
+ret: {
+        u16 reg = NEXT_PAYLOAD;
 #ifdef HEX_DEBUG
-    Log->debug("");
-
-    if (auto* top = StackTop(); StackSize() > 0) {
-        if (top->GetType() == mana::PrimitiveType::Bool) {
-            Log->debug("[ret: {}]\n\n", Pop().AsBool());
-        } else {
-            Log->debug("[ret: {}]\n\n", Pop().AsFloat());
-        }
-    } else {
-        Log->warn("Attempted to return from empty stack");
-    }
-#else
-    POP();
+        Log->debug("");
+        Log->debug("[ret: {} <- R{}]", REG(reg).AsFloat(), reg);
 #endif
 
-    DISPATCH();
-
-push:
-    PUSH(FETCH_CONSTANT());
-    ip += payload_size;
-    LOG_TOP("[push:  {}]");
-
-    DISPATCH();
-
-pop:
-    LOG_TOP("[pop:  {}]");
-    POP();
-
-    DISPATCH();
-
-load:
-    PUSH(locals[READ_PAYLOAD]);
-    LOG_DATUM("[load {} => slot {}]");
-
-    ip += payload_size;
-
-    DISPATCH();
-
-store:
-    locals[READ_PAYLOAD] = POP();
-    LOG_DATUM("[store {} => slot {}]");
-
-    ip += payload_size;
-
-    DISPATCH();
-
-negate:
-    TOP_VAL() *= -1;
-    LOG_TOP("neg:   {}");
-
-    DISPATCH();
-
-add:
-    LOG_TOP_TWO("add: ({}, {})");
-    TOP_VAL() += POP();
-
-    DISPATCH();
-
-sub:
-    LOG_TOP_TWO("sub: ({}, {})");
-    TOP_VAL() -= POP();
-
-    DISPATCH();
-
-div:
-    LOG_TOP_TWO("div: ({}, {})");
-    TOP_VAL() /= POP();
-
-    DISPATCH();
-
-mul:
-    LOG_TOP_TWO("mul: ({}, {})");
-    TOP_VAL() *= POP();
-
-    DISPATCH();
-
-cmp_greater:
-    LOG_TOP_TWO("cmp_greater: ({}, {})");
-    PUSH(CMP(>));
-
-    DISPATCH();
-
-cmp_greater_eq:
-    LOG_TOP_TWO("cmp_greater_eq: ({}, {})");
-    PUSH(CMP(>=));
-
-    DISPATCH();
-
-cmp_lesser:
-    LOG_TOP_TWO("cmp_lesser: ({}, {})");
-    PUSH(CMP(<));
-
-    DISPATCH();
-
-cmp_lesser_eq:
-    LOG_TOP_TWO("cmp_lesser_eq: ({}, {})");
-    PUSH(CMP(<=));
-
-    DISPATCH();
-
-equals:
-    LOG_TOP_TWO("equals ({}, {})");
-    PUSH(CMP(==));
-
-    DISPATCH();
-
-not_equals:
-    LOG_TOP_TWO("not_equals ({}, {})");
-    PUSH(CMP(!=));
-
-    DISPATCH();
-
-bool_not:
-    LOG_TOP("not ({})");
-    LOGICAL_NOT();
-
-    DISPATCH();
-
-jmp:
-    LOG_JMP("jmp: {}", READ_PAYLOAD);
-    ip += READ_PAYLOAD + payload_size;
-
-    DISPATCH();
-
-jwf:
-    LOG_JMP("jmp-false: {}", JWF_DIST);
-    ip += JWF_DIST + payload_size;
-
-    DISPATCH();
-
-jwt:
-    LOG_JMP("jmp-true: {}", JWT_DIST);
-    ip += JWT_DIST + payload_size;
-
-    DISPATCH();
-
-compile_error:
-    return InterpretResult::CompileError;
-}
-
-u64 VirtualMachine::StackSize() const {
-    return stack_top - stack.data();
-}
-
-void VirtualMachine::Reset() {
-    stack_top = stack.data();
-}
-
-void VirtualMachine::Push(const Value& value) {
-    if (stack_top == &stack.back()) {
-        const auto offset = stack.size();
-        stack.resize(stack.capacity() * 2);
-
-        stack_top = stack.data() + offset;
+        DISPATCH();
     }
 
-    *stack_top = value;
-    ++stack_top;
-}
+load_constant: {
+        u16 dst  = NEXT_PAYLOAD;
+        u16 idx  = NEXT_PAYLOAD;
+        REG(dst) = constants[idx];
 
-Value VirtualMachine::Pop() {
-    if (stack_top != &stack.front()) {
-        --stack_top;
-    } else {
-        Log->error("Attempted to pop from empty stack.");
-        return 0.0;
+        DISPATCH();
+    }
+move: {
+        u16 dst  = NEXT_PAYLOAD;
+        u16 src  = NEXT_PAYLOAD;
+        REG(dst) = REG(src);
+
+        DISPATCH();
     }
 
-    return *stack_top;
-}
+#define BINARY_OP(op)       \
+    u16 dst = NEXT_PAYLOAD; \
+    u16 lhs = NEXT_PAYLOAD; \
+    u16 rhs = NEXT_PAYLOAD; \
+    REG(dst) = REG(lhs) op REG(rhs)
 
-Value VirtualMachine::ViewTop() const {
-    if (stack_top == &stack.front()) {
-        Log->error("Attempted to read from empty stack");
-        return 0.0;
+add: {
+        BINARY_OP(+);
+        DISPATCH();
     }
 
-    return *(stack_top - 1);
-}
-
-Value* VirtualMachine::StackTop() const {
-    if (stack_top == &stack.front()) {
-        Log->warn("Attempted to read from empty stack");
-        return nullptr;
+sub: {
+        BINARY_OP(-);
+        DISPATCH();
     }
 
-    return stack_top - 1;
-}
-
-void VirtualMachine::LogTop(const std::string_view msg) const {
-    if (StackTop()->GetType() == mana::PrimitiveType::Bool) {
-        Log->debug(fmt::runtime(msg), ViewTop().AsBool());
-    } else {
-        Log->debug(fmt::runtime(msg), ViewTop().AsFloat());
+div: {
+        BINARY_OP(/);
+        DISPATCH();
     }
-}
 
-void VirtualMachine::LogTopTwo(const std::string_view msg) const {
-    if (StackTop()->GetType() == mana::PrimitiveType::Bool) {
-        Log->debug(fmt::runtime(msg), (StackTop() - 1)->AsBool(), ViewTop().AsBool());
-    } else {
-        Log->debug(fmt::runtime(msg), (StackTop() - 1)->AsFloat(), ViewTop().AsFloat());
+mul: {
+        BINARY_OP(*);
+        DISPATCH();
     }
-}
 
-void VirtualMachine::LogLocalDatum(std::string_view msg) const {
-    Log->debug(fmt::runtime(msg)
-         , locals[READ_PAYLOAD].GetType() == mana::PrimitiveType::Bool
-               ? locals[READ_PAYLOAD].AsBool()
-               : locals[READ_PAYLOAD].AsFloat()
-         , READ_PAYLOAD);
+negate: {
+        u16 dst  = NEXT_PAYLOAD;
+        u16 src  = NEXT_PAYLOAD;
+        REG(dst) = -REG(src);
+
+        DISPATCH();
+    }
+
+bool_not: {
+        u16 dst  = NEXT_PAYLOAD;
+        u16 src  = NEXT_PAYLOAD;
+        REG(dst) = !REG(src);
+
+        DISPATCH();
+    }
+
+cmp_greater: {
+        BINARY_OP(>);
+        DISPATCH();
+    }
+
+cmp_greater_eq: {
+        BINARY_OP(>=);
+        DISPATCH();
+    }
+
+cmp_lesser: {
+        BINARY_OP(<);
+        DISPATCH();
+    }
+
+cmp_lesser_eq: {
+        BINARY_OP(<=);
+        DISPATCH();
+    }
+
+equals: {
+        BINARY_OP(==);
+        DISPATCH();
+    }
+
+not_equals: {
+        BINARY_OP(!=);
+        DISPATCH();
+    }
+
+jmp: {
+        ip += NEXT_PAYLOAD;
+        DISPATCH();
+    }
+
+jmp_true: {
+        u16 reg  = NEXT_PAYLOAD;
+        u16 dist = NEXT_PAYLOAD;
+
+        // sidestep branch predictions altogether
+        ip += dist * REG(reg).AsBool();
+
+        DISPATCH();
+    }
+jmp_false: {
+        u16 reg  = NEXT_PAYLOAD;
+        u16 dist = NEXT_PAYLOAD;
+
+        // this just inverts the output
+        ip += dist * ((REG(reg).AsBool() - 1) * -1);
+
+        DISPATCH();
+    }
+
+compile_error: {
+        return InterpretResult::CompileError;
+    }
 }
 } // namespace hex

--- a/projects/hex/src/hex/vm/virtual-machine.cpp
+++ b/projects/hex/src/hex/vm/virtual-machine.cpp
@@ -6,7 +6,7 @@
 namespace hex {
 using namespace mana::vm;
 
-static constexpr std::size_t BASE_REG_SIZE = 32;
+static constexpr std::size_t BASE_REG_SIZE = 256;
 
 // payloads are little endian
 #define READ_PAYLOAD (static_cast<u16>(*ip | *(ip + 1) << 8))

--- a/projects/mana-core/include/mana/vm/opcode.hpp
+++ b/projects/mana-core/include/mana/vm/opcode.hpp
@@ -5,21 +5,24 @@
 namespace mana::vm {
 using namespace literals;
 
+constexpr u8 BASE_REGISTERS = 128;
+constexpr u8 CJMP_OP_BYTES  = 5;
+constexpr u8 JMP_OP_BYTES   = 3;
+
+
 enum class Op : u8 {
     Halt,
 
-    Return,        // Op Reg       -> Place value in Reg
-    LoadConstant,  // Op Reg Const -> Reg = Constants[Const]
-    Move,          // Op Dst Src   -> Dst = Src
-
-    Add,           // Op Dst L R   -> Dst = L + R
-    Sub,           // etc.
+    Return,       // Op Reg       -> Place value in Reg
+    LoadConstant, // Op Reg Const -> Reg = Constants[Const]
+    Move,         // Op Dst Src   -> Dst = Src
+    Add,          // Op Dst L R   -> Dst = L + R
+    Sub,          // etc.
     Div,
     Mul,
 
     Negate,        // Op Dst Src   -> Dst = -Src
     Not,           // Op Dst Src   -> Dst = !Src
-
     Cmp_Greater,   // Op Dst L R   -> Dst = L > R
     Cmp_GreaterEq, // etc.
     Cmp_Lesser,

--- a/projects/mana-core/include/mana/vm/opcode.hpp
+++ b/projects/mana-core/include/mana/vm/opcode.hpp
@@ -8,33 +8,28 @@ using namespace literals;
 enum class Op : u8 {
     Halt,
 
-    Return,
+    Return,        // Op Reg       -> Place value in Reg
+    LoadConstant,  // Op Reg Const -> Reg = Constants[Const]
+    Move,          // Op Dst Src   -> Dst = Src
 
-    Push,
-    Pop,
-    Load,
-    Store,
-
-    Negate,
-
-    Add,
-    Sub,
+    Add,           // Op Dst L R   -> Dst = L + R
+    Sub,           // etc.
     Div,
     Mul,
 
-    Cmp_Greater,
-    Cmp_GreaterEq,
+    Negate,        // Op Dst Src   -> Dst = -Src
+    Not,           // Op Dst Src   -> Dst = !Src
+
+    Cmp_Greater,   // Op Dst L R   -> Dst = L > R
+    Cmp_GreaterEq, // etc.
     Cmp_Lesser,
     Cmp_LesserEq,
 
     Equals,
     NotEquals,
 
-    Not,
-
-    Jump,
-    JumpWhenFalse,
-    JumpWhenTrue,
+    Jump,          // Op Offset       -> Jump by Offset
+    JumpWhenTrue,  // Op Reg Offset   -> if Reg { ip += Offset }
+    JumpWhenFalse, // etc.
 };
-
-}  // namespace mana::vm
+} // namespace mana::vm

--- a/projects/mana-core/include/mana/vm/slice.hpp
+++ b/projects/mana-core/include/mana/vm/slice.hpp
@@ -26,17 +26,17 @@ class Slice {
     std::vector<Value> values;
 
 public:
-    // returns index where opcode was written
+    // returns opcode's index
     u64 Write(Op opcode);
 
-    // returns the index of the opcode, not the payload
-    u64 Write(Op opcode, u16 payload);
+    // returns opcode's index
+    u64 Write(Op opcode, std::initializer_list<u16> payloads);
 
     // Modifies a payload for the given opcode
     // This function exists to amend instruction payloads,
     // and thus it assumes the index given is for the opcode whose payload you wish to patch,
     // not the payload itself
-    void Patch(u64 instruction_index, u16 new_value);
+    void Patch(u64 instruction_index, u16 new_value, u8 payload_index = 0);
 
     MANA_NODISCARD u64 BackIndex() const;
 

--- a/projects/mana-core/include/mana/vm/value.hpp
+++ b/projects/mana-core/include/mana/vm/value.hpp
@@ -57,6 +57,13 @@ struct Value {
     MANA_NODISCARD u64  AsUint() const;
     MANA_NODISCARD bool AsBool() const;
 
+    Value operator+(const Value& rhs) const;
+    Value operator-(const Value& rhs) const;
+    Value operator*(const Value& rhs) const;
+    Value operator/(const Value& rhs) const;
+
+    Value operator-() const;
+
     void operator+=(const Value& rhs);
     void operator-=(const Value& rhs);
     void operator*=(const Value& rhs);
@@ -86,57 +93,6 @@ struct Value {
     Value& operator=(Value&& other) noexcept;
 
     ~Value();
-
-    // template <typename T>
-    //     requires std::is_integral_v<T> || std::is_floating_point_v<T>
-    //              || std::is_same_v<T, bool>
-    // explicit Value(const std::vector<T>& values)
-    //     : length(values.size())
-    //     , type(GetManaTypeFrom(T{})) {
-    //     if (length == 0) {
-    //         data = nullptr;
-    //         return;
-    //     }
-    //
-    //     if (length == 1) {
-    //         switch (type) {
-    //         case Int64:
-    //             data = new Data{.as_i64 = values[0]};
-    //             return;
-    //         case Uint64:
-    //             data = new Data{.as_u64 = values[0]};
-    //             return;
-    //         case Float64:
-    //             data = new Data{.as_f64 = values[0]};
-    //             return;
-    //         case Bool:
-    //             data = new Data{.as_bool = values[0]};
-    //             return;
-    //         default:
-    //             break;
-    //         }
-    //     }
-    //
-    //     data = new Data[length];
-    //     for (u64 i = 0; i < length; ++i) {
-    //         switch (type) {
-    //         case Int64:
-    //             data[i].as_i64 = values[i];
-    //             break;
-    //         case Uint64:
-    //             data[i].as_u64 = values[i];
-    //             break;
-    //         case Float64:
-    //             data[i].as_f64 = values[i];
-    //             break;
-    //         case Bool:
-    //             data[i].as_bool = values[i];
-    //             break;
-    //         default:
-    //             return;
-    //         }
-    //     }
-    // }
 
     template <typename T>
         requires std::is_integral_v<T>

--- a/projects/mana-core/src/mana/vm/slice.cpp
+++ b/projects/mana-core/src/mana/vm/slice.cpp
@@ -17,20 +17,25 @@ u64 Slice::Write(Op opcode) {
     return instructions.size() - 1;
 }
 
-u64 Slice::Write(const Op opcode, const u16 payload) {
+u64 Slice::Write(const Op opcode, std::initializer_list<u16> payloads) {
     instructions.push_back(static_cast<u8>(opcode));
-    const auto ret = instructions.size() - 1;
+    const auto index = instructions.size() - 1;
 
     // payloads are 16-bit unsigned little endian
-    instructions.push_back(payload & 0xFF);
-    instructions.push_back((payload >> 8) & 0xFF);
 
-    return ret;
+    for (const auto payload : payloads) {
+        instructions.push_back(payload & 0xFF);
+        instructions.push_back((payload >> 8) & 0xFF);
+    }
+
+    return index;
 }
 
-void Slice::Patch(const u64 instruction_index, const u16 new_value) {
-    instructions[instruction_index + 1] = new_value & 0xFF;
-    instructions[instruction_index + 2] = (new_value >> 8) & 0xFF;
+void Slice::Patch(const u64 instruction_index, const u16 new_value, const u8 payload_index) {
+    // add 1 to skip past instruction
+    const u64 payload = 1 + instruction_index + payload_index * 2;
+    instructions[payload] = new_value & 0xFF;
+    instructions[payload + 1] = (new_value >> 8) & 0xFF;
 }
 
 u64 Slice::BackIndex() const {

--- a/projects/mana-core/src/mana/vm/value.cpp
+++ b/projects/mana-core/src/mana/vm/value.cpp
@@ -302,8 +302,8 @@ Value::~Value() {
     }
 }
 
-#define CGOTO_OPERATOR_CMP(ret, op)                   \
-    ret Value::operator op(const Value & rhs) const { \
+#define CGOTO_OPERATOR_BIN(ret, op)                   \
+    ret Value::operator op(const Value& rhs) const {  \
         COMPUTED_GOTO();                              \
     CASE_INT:                                         \
         return data->as_i64 op rhs.AsInt();           \
@@ -315,8 +315,8 @@ Value::~Value() {
         UNREACHABLE();                                \
     }
 
-#define CGOTO_OPERATOR_ARITH_ASSIGN(op)          \
-    void Value::operator op(const Value & rhs) { \
+#define CGOTO_OPERATOR_BIN_ASSIGN(op)            \
+    void Value::operator op(const Value& rhs) {  \
         COMPUTED_GOTO();                         \
     CASE_INT:                                    \
         data->as_i64 op rhs.AsInt();             \
@@ -331,15 +331,33 @@ Value::~Value() {
         UNREACHABLE();                           \
     }
 
-CGOTO_OPERATOR_ARITH_ASSIGN(+=);
-CGOTO_OPERATOR_ARITH_ASSIGN(-=);
-CGOTO_OPERATOR_ARITH_ASSIGN(*=);
-CGOTO_OPERATOR_ARITH_ASSIGN(/=);
+CGOTO_OPERATOR_BIN(Value, +);
+CGOTO_OPERATOR_BIN(Value, -);
+CGOTO_OPERATOR_BIN(Value, *);
+CGOTO_OPERATOR_BIN(Value, /)
 
-CGOTO_OPERATOR_CMP(bool, >);
-CGOTO_OPERATOR_CMP(bool, >=);
-CGOTO_OPERATOR_CMP(bool, <);
-CGOTO_OPERATOR_CMP(bool, <=);
+CGOTO_OPERATOR_BIN_ASSIGN(+=);
+CGOTO_OPERATOR_BIN_ASSIGN(-=);
+CGOTO_OPERATOR_BIN_ASSIGN(*=);
+CGOTO_OPERATOR_BIN_ASSIGN(/=);
+
+CGOTO_OPERATOR_BIN(bool, >);
+CGOTO_OPERATOR_BIN(bool, >=);
+CGOTO_OPERATOR_BIN(bool, <);
+CGOTO_OPERATOR_BIN(bool, <=);
+
+Value Value::operator-() const {
+    COMPUTED_GOTO();
+
+    CASE_INT:
+        return Value{-data->as_i64};
+    CASE_UNSIGNED:
+        UNREACHABLE();
+    CASE_FLOAT:
+        return Value{-data->as_f64};
+    CASE_BOOL:
+        UNREACHABLE();
+}
 
 bool Value::operator!() const {
     return not data->as_bool;

--- a/projects/sigil/include/sigil/ast/syntax-tree.hpp
+++ b/projects/sigil/include/sigil/ast/syntax-tree.hpp
@@ -84,12 +84,12 @@ public:
     void                             Accept(Visitor& visitor) const override;
 };
 
-class Datum final : public Node {
+class DataDeclaration final : public Node {
     std::string name;
     NodePtr     initializer;
 
 public:
-    explicit Datum(const ParseNode& node);
+    explicit DataDeclaration(const ParseNode& node);
 
     SIGIL_NODISCARD std::string_view GetName() const;
     SIGIL_NODISCARD const NodePtr&   GetInitializer() const;
@@ -98,7 +98,7 @@ public:
 };
 
 class Scope final : public Node, public StatementContainer {
-    std::unordered_map<std::string, Datum*> datums;
+    std::unordered_map<std::string, DataDeclaration*> datums;
 
 public:
     explicit Scope(const ParseNode& node);
@@ -214,7 +214,7 @@ void PropagateStatements(const ParseNode& node, SC* root) {
 
             switch (n->rule) {
             case Declaration:
-                root->Add<Datum>(*n);
+                root->Add<DataDeclaration>(*n);
                 break;
             case IfBlock:
                 root->Add<If>(*n);

--- a/projects/sigil/include/sigil/ast/visitor.hpp
+++ b/projects/sigil/include/sigil/ast/visitor.hpp
@@ -14,7 +14,7 @@ public:
     virtual void Visit(const class Artifact& node)     = 0;
     virtual void Visit(const class Scope& node)        = 0;
 
-    virtual void Visit(const class Datum& node)        = 0;
+    virtual void Visit(const class DataDeclaration& node)        = 0;
     virtual void Visit(const class Identifier& node)   = 0;
 
     virtual void Visit(const class Statement& node)    = 0;

--- a/projects/sigil/src/sigil/ast/syntax-tree.cpp
+++ b/projects/sigil/src/sigil/ast/syntax-tree.cpp
@@ -127,9 +127,7 @@ Scope::Scope(const ParseNode& node) {
 }
 
 void Scope::Accept(Visitor& visitor) const {
-    for (const auto& stmt : statements) {
-        stmt->Accept(visitor);
-    }
+    visitor.Visit(*this);
 }
 
 const std::vector<NodePtr>& Scope::GetStatements() const {

--- a/projects/sigil/src/sigil/ast/syntax-tree.cpp
+++ b/projects/sigil/src/sigil/ast/syntax-tree.cpp
@@ -173,7 +173,7 @@ void If::Accept(Visitor& visitor) const {
 }
 
 /// Datum
-Datum::Datum(const ParseNode& node) : initializer(nullptr) {
+DataDeclaration::DataDeclaration(const ParseNode& node) : initializer(nullptr) {
     // Correctly find the identifier name among tokens (skip 'mut' or 'data')
     for (const auto& token : node.tokens) {
         if (token.type == TokenType::Identifier) {
@@ -186,15 +186,15 @@ Datum::Datum(const ParseNode& node) : initializer(nullptr) {
     }
 }
 
-std::string_view Datum::GetName() const {
+std::string_view DataDeclaration::GetName() const {
     return name;
 }
 
-const NodePtr& Datum::GetInitializer() const {
+const NodePtr& DataDeclaration::GetInitializer() const {
     return initializer;
 }
 
-void Datum::Accept(Visitor& visitor) const {
+void DataDeclaration::Accept(Visitor& visitor) const {
     visitor.Visit(*this);
 }
 


### PR DESCRIPTION
This overhauls the VM and BCC to work with register-based bytecode instead of stack-based, since that is something we had to do eventually anyway. It also fixes many critical and subtle bugs that could've caused pretty catastrophic failures. Overall, Hex and Circe are far more robust now, and there's less macro garbage. The code is more concise and maintainable, and is ready to add new features.

Circe, however, still needs many improvements. There's still a lot of mess around the AST.