### PR TITLE
Add value printing functionality

### DIFF
--- a/assets/samples/hello-world.mn
+++ b/assets/samples/hello-world.mn
@@ -1,4 +1,12 @@
 fn Main() {
-    Print("Hey!\n\n\n\n\n")
-    Print("I'm\nwalkin'\nhere!")
+    PrintV("I got {} bucks says ya can't do a wooglie\n\n", 8)
+
+    data whoa = "'hoosh'\n"
+    PrintV("Met this crazy lady and she was all like {}\n", whoa)
+
+    data real = true
+    PrintV("It's {}, I be profen all day\n\n", real)
+
+    data f = 97.1
+    PrintV("I be doin' {} on a gummy twirly-o\n\n", f)
 }

--- a/assets/samples/hello-world.mn
+++ b/assets/samples/hello-world.mn
@@ -1,4 +1,4 @@
 fn Main() {
-    Print("Hey!\n\n")
+    Print("Hey!\n\n\n\n\n")
     Print("I'm\nwalkin'\nhere!")
 }

--- a/assets/samples/hello-world.mn
+++ b/assets/samples/hello-world.mn
@@ -1,4 +1,4 @@
 fn Main() {
     Print("Hey!\n")
-    Print("I'm walkin' here!")
+    Print("I'm\nwalkin'\nhere!")
 }

--- a/assets/samples/hello-world.mn
+++ b/assets/samples/hello-world.mn
@@ -1,4 +1,4 @@
 fn Main() {
-    Print("Hey!")
+    Print("Hey!\n")
     Print("I'm walkin' here!")
 }

--- a/assets/samples/hello-world.mn
+++ b/assets/samples/hello-world.mn
@@ -1,4 +1,4 @@
 fn Main() {
-    Print("Hey!\n")
+    Print("Hey!\n\n")
     Print("I'm\nwalkin'\nhere!")
 }

--- a/modules/circe/src/bytecode-generator.cpp
+++ b/modules/circe/src/bytecode-generator.cpp
@@ -189,13 +189,26 @@ void BytecodeGenerator::Visit(const Return& node) {
 }
 
 void BytecodeGenerator::Visit(const Invocation& node) {
-    const auto name = node.GetIdentifier();
-    const auto& fn  = functions[name];
+    const auto name  = node.GetIdentifier();
+    const auto& args = node.GetArguments();
+    const auto& fn   = functions[name];
 
     // handle print
     if (name == "Print") {
-        node.GetArguments().back()->Accept(*this);
+        args[0]->Accept(*this);
         bytecode.Write(Op::Print, {PopRegBuffer()});
+
+        register_buffer.push_back(REGISTER_RETURN);
+        return;
+    }
+
+    if (name == "PrintV") {
+        args[0]->Accept(*this);
+        const auto str_reg = PopRegBuffer();
+        args[1]->Accept(*this);
+        const auto val = PopRegBuffer();
+
+        bytecode.Write(Op::PrintValue, {str_reg, val});
 
         register_buffer.push_back(REGISTER_RETURN);
         return;

--- a/modules/hex/include/hex/core/debug.hpp
+++ b/modules/hex/include/hex/core/debug.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+// this file contains all macros for printing out every single Hex instruction
+// now that we can print values, this should generally be avoided, as it
+// drastically slows down execution

--- a/modules/hex/include/hex/hex.hpp
+++ b/modules/hex/include/hex/hex.hpp
@@ -31,5 +31,7 @@ class Hex {
 
 public:
     InterpretResult Execute(hexe::ByteCode* next_slice);
+
+    std::string ValueToString(const hexe::Value& value);
 };
 } // namespace hex

--- a/modules/hex/src/core/disassembly.cpp
+++ b/modules/hex/src/core/disassembly.cpp
@@ -88,6 +88,7 @@ void PrintBytecode(const ByteCode& s) {
 
         case Move:
         case Negate:
+        case PrintValue:
         case Not: {
             const u16 dst = read();
             const u16 src = read();

--- a/modules/hex/src/hex.cpp
+++ b/modules/hex/src/hex.cpp
@@ -60,28 +60,10 @@ InterpretResult Hex::Execute(ByteCode* bytecode) {
         &&jmp_false,
         &&call,
         &&print,
+        &&print_val,
     };
 
 #ifdef HEX_DEBUG
-    const auto ValueToString = [](const Value& v) -> std::string {
-        using namespace mana;
-        switch (v.GetType()) {
-        case Int64:
-            return std::to_string(v.AsInt());
-        case Uint64:
-            return std::to_string(v.AsUint());
-        case Float64:
-            return fmt::format("{:.2f}", v.AsFloat());
-        case Bool:
-            return v.AsBool() ? "true" : "false";
-        case String:
-            return std::string {v.AsString()};
-        case None:
-            return "none";
-        default:
-            return "???";
-        }
-    };
 #   define DISPATCH()                                                                          \
     {                                                                                          \
         const auto offset = ip - bytecode->Instructions().data();                              \
@@ -334,5 +316,33 @@ print: {
         std::print("{}", s);
     }
     DISPATCH();
+
+print_val: {
+        const auto s = REG(NEXT_PAYLOAD).AsString();
+        const auto v = ValueToString(REG(NEXT_PAYLOAD));
+
+        std::vprint_nonunicode(s, std::make_format_args(v));
+    }
+    DISPATCH();
 }
+
+std::string Hex::ValueToString(const Value& v) {
+    using namespace mana;
+    switch (v.GetType()) {
+    case Int64:
+        return std::to_string(v.AsInt());
+    case Uint64:
+        return std::to_string(v.AsUint());
+    case Float64:
+        return fmt::format("{:.2f}", v.AsFloat());
+    case Bool:
+        return v.AsBool() ? "true" : "false";
+    case String:
+        return std::string {v.AsString()};
+    case None:
+        return "none";
+    default:
+        return "???";
+    }
+};
 } // namespace hex

--- a/modules/hex/src/hex.cpp
+++ b/modules/hex/src/hex.cpp
@@ -5,6 +5,7 @@
 #include <magic_enum/magic_enum.hpp>
 
 #include <array>
+#include <print>
 
 namespace hex {
 using namespace hexe;
@@ -103,7 +104,7 @@ InterpretResult Hex::Execute(ByteCode* bytecode) {
     DISPATCH();
 
 halt:
-    Log->info("");
+    std::print("\n\n");
     Log->set_pattern("%^<%n>%$ %v");
     return InterpretResult::OK;
 
@@ -331,7 +332,7 @@ call: {
 print: {
         u16 reg      = NEXT_PAYLOAD;
         const auto s = REG(reg).AsString();
-        Log->info("{}", s);
+        std::print("{}", s);
     }
     DISPATCH();
 }

--- a/modules/hex/src/hex.cpp
+++ b/modules/hex/src/hex.cpp
@@ -330,8 +330,7 @@ call: {
         DISPATCH();
     }
 print: {
-        u16 reg      = NEXT_PAYLOAD;
-        const auto s = REG(reg).AsString();
+        const auto s = REG(NEXT_PAYLOAD).AsString();
         std::print("{}", s);
     }
     DISPATCH();

--- a/modules/hex/src/hex.cpp
+++ b/modules/hex/src/hex.cpp
@@ -1,5 +1,6 @@
 #include <hex/core/logger.hpp>
 #include <hex/hex.hpp>
+#include <hex/core/debug.hpp>
 
 #include <magic_enum/magic_enum.hpp>
 

--- a/modules/mana-core/include/hexe/opcode.hpp
+++ b/modules/mana-core/include/hexe/opcode.hpp
@@ -46,7 +46,8 @@ enum class Op : u8 {
                    //            == Record register frame, then jump to function at address.
                    //            == Upon returning, retval is copied into designated return register and frame is returned to previous position
 
-    Print,         // Op Src     -> Emits value at `Src` to stdout
+    Print,         // Op Str     -> Emit `Str` to stdout
+    PrintValue,        // Op Str Val -> Emit 'Str' to stdout with a value argument
 };
 // @formatter:on
 } // namespace hexe

--- a/modules/sigil/include/sigil/ast/lexer.hpp
+++ b/modules/sigil/include/sigil/ast/lexer.hpp
@@ -53,6 +53,7 @@ private:
     SIGIL_NODISCARD bool IsWhitespace(char c) const;
     SIGIL_NODISCARD bool IsLineComment() const;
     SIGIL_NODISCARD bool IsNewline() const;
+    SIGIL_NODISCARD bool IsNewline(char c) const;
 
     void AddEOF();
 };

--- a/modules/sigil/include/sigil/ast/syntax-tree.hpp
+++ b/modules/sigil/include/sigil/ast/syntax-tree.hpp
@@ -357,26 +357,11 @@ class StringLiteral final : public Node {
     std::string string;
 
 public:
-    explicit StringLiteral(const std::string_view sv) {
-        // unescape newlines
-        string.reserve(sv.size());
-        for (i64 i = 0; i < sv.size(); ++i) {
-            if (sv[i] == '\\' && i + 1 < sv.size() && sv[i + 1] == 'n') {
-                string.push_back('\n');
-                ++i;
-            } else {
-                string.push_back(sv[i]);
-            }
-        }
-    }
+    explicit StringLiteral(const std::string_view sv);
 
-    SIGIL_NODISCARD std::string_view Get() const {
-        return string;
-    }
+    SIGIL_NODISCARD std::string_view Get() const;
 
-    void Accept(Visitor& visitor) const override {
-        visitor.Visit(*this);
-    }
+    void Accept(Visitor& visitor) const override;
 };
 
 class ArrayLiteral final : public Node {

--- a/modules/sigil/include/sigil/ast/syntax-tree.hpp
+++ b/modules/sigil/include/sigil/ast/syntax-tree.hpp
@@ -354,14 +354,24 @@ public:
 };
 
 class StringLiteral final : public Node {
-    std::string value;
+    std::string string;
 
 public:
-    explicit StringLiteral(const std::string_view value)
-        : value(value) {}
+    explicit StringLiteral(const std::string_view sv) {
+        // unescape newlines
+        string.reserve(sv.size());
+        for (i64 i = 0; i < sv.size(); ++i) {
+            if (sv[i] == '\\' && i + 1 < sv.size() && sv[i + 1] == 'n') {
+                string.push_back('\n');
+                ++i;
+            } else {
+                string.push_back(sv[i]);
+            }
+        }
+    }
 
     SIGIL_NODISCARD std::string_view Get() const {
-        return value;
+        return string;
     }
 
     void Accept(Visitor& visitor) const override {

--- a/modules/sigil/src/ast/lexer.cpp
+++ b/modules/sigil/src/ast/lexer.cpp
@@ -21,7 +21,11 @@ Lexer::Lexer()
       line_number {0} {}
 
 bool Lexer::IsNewline() const {
-    return Source[cursor] == '\n';
+    return IsNewline(Source[cursor]);
+}
+
+bool Lexer::IsNewline(char c) const {
+    return c == '\n';
 }
 
 void Lexer::TokenizeLine() {
@@ -147,14 +151,14 @@ bool Lexer::LexedString() {
             return false;
         }
 
-        current_char = Source[cursor];
-
         // strings must close on the line they're started
-        if (current_char == '\n' || (current_char == '\\' && Source[cursor + 1] == 'n')) {
+        if (IsNewline()) {
             Log->error("Unexpected end of string literal");
             AddToken(TokenType::Unknown, length);
             return false;
         }
+
+        current_char = Source[cursor];
 
         // end of string
         if (current_char == starting_char) {

--- a/modules/sigil/src/ast/semantic-analyzer.cpp
+++ b/modules/sigil/src/ast/semantic-analyzer.cpp
@@ -396,10 +396,15 @@ void SemanticAnalyzer::RegisterPrimitives() {
 }
 
 void SemanticAnalyzer::RegisterBuiltins() {
-    auto& fn         = GetFnTable()["Print"];
-    fn.return_type   = PrimitiveName(None);
-    fn.param_count   = 1;
-    fn.locals["str"] = {PrimitiveName(String), true};
+    auto& print         = GetFnTable()["Print"];
+    print.return_type   = PrimitiveName(None);
+    print.param_count   = 1;
+    print.locals["str"] = {PrimitiveName(String), true};
+
+    auto& printv         = GetFnTable()["PrintV"];
+    printv.return_type   = PrimitiveName(None);
+    printv.param_count   = 2;
+    printv.locals["str"] = {PrimitiveName(String), true};
 }
 
 FunctionTable& SemanticAnalyzer::GetFnTable() {

--- a/modules/sigil/src/ast/syntax-tree.cpp
+++ b/modules/sigil/src/ast/syntax-tree.cpp
@@ -615,7 +615,7 @@ StringLiteral::StringLiteral(const std::string_view sv) {
         if (sv[i] == '\\' && sv[i + 1] == 'n') {
             string.append(sv.substr(last_append, i - last_append));
             string.push_back('\n');
-            last_append = i += 2;
+            last_append = i++ + 2;
         }
     }
     string.append(sv.substr(last_append, sv.size() - last_append));

--- a/modules/sigil/src/ast/syntax-tree.cpp
+++ b/modules/sigil/src/ast/syntax-tree.cpp
@@ -606,6 +606,29 @@ BinaryExpr::BinaryExpr(const ParseNode& binary_node, const i64 depth) {
     op    = FetchTokenText(tokens[tokens.size() - depth]);
 }
 
+/// StringLiteral
+StringLiteral::StringLiteral(const std::string_view sv) {
+    // unescape newlines
+    string.reserve(sv.size());
+    i64 last_append {};
+    for (i64 i = 0; i < sv.size() - 1; ++i) {
+        if (sv[i] == '\\' && sv[i + 1] == 'n') {
+            string.append(sv.substr(last_append, i - last_append));
+            string.push_back('\n');
+            last_append = i += 2;
+        }
+    }
+    string.append(sv.substr(last_append, sv.size() - last_append));
+}
+
+std::string_view StringLiteral::Get() const {
+    return string;
+}
+
+void StringLiteral::Accept(Visitor& visitor) const {
+    visitor.Visit(*this);
+}
+
 /// ArrayLiteral
 ArrayLiteral::ArrayLiteral(const ParseNode& node)
     : type(hexe::ValueType::Invalid) {


### PR DESCRIPTION
Adds the ability to print values of different types within strings.

This change introduces a new `PrintValue` opcode and a `PrintV` builtin function, allowing for formatted output of a single value with interpolation. It also replaces the internal logger with `std::print` for user output when `Print` or `PrintV` are invoked.

Currently no plans for PrintLn yet, would be too much of a hassle. Though we could make `Print` take an optional set of arguments once overloads are implemented.